### PR TITLE
Update initialize for all entry iterators to check existing paths

### DIFF
--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDirCommandWithIso9660.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDirCommandWithIso9660.cs
@@ -1,0 +1,212 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hst.Imager.Core.Commands;
+using Hst.Imager.Core.Models.FileSystems;
+using Hst.Imager.Core.PathComponents;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Hst.Imager.Core.Tests.CommandTests.FsCommandTests;
+
+public class GivenFsDirCommandWithIso9660 : FsCommandTestBase
+{
+    [Theory]
+    [InlineData("", true)]
+    [InlineData("", false)]
+    [InlineData("*", true)]
+    [InlineData("*", false)]
+    [InlineData("file1.txt", true)]
+    [InlineData("file1.txt", false)]
+    [InlineData("dir1", true)]
+    [InlineData("dir1", false)]
+    [InlineData("dir1\\t*", true)]
+    [InlineData("dir1\\t*", false)]
+    [InlineData("dir1\\test.txt", true)]
+    [InlineData("dir1\\test.txt", false)]
+    [InlineData("dir1\\dir2", true)]
+    [InlineData("dir1\\dir2", false)]
+    [InlineData("dir1\\dir2\\*", true)]
+    [InlineData("dir1\\dir2\\*", false)]
+    public async Task When_ListingEntriesInExisting_Then_EntriesAreListed(string path, bool recursive)
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.iso";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+        
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - create iso9660 image with directories and files
+            CreateIso9660WithDirectoriesAndFiles(mediaPath);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+            EntriesInfo entriesInfo = null;
+            fsDirCommand.EntriesRead += (_, args) =>
+            {
+                entriesInfo = args.EntriesInfo;
+            };
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is success with one entry
+            Assert.NotNull(result);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(entriesInfo);
+            Assert.NotEmpty(entriesInfo.Entries);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("x*")]
+    [InlineData("test4*")]
+    [InlineData("dir1\\e*")]
+    public async Task When_ListingEntriesInExistingDirectoryWithPatternNotMatching_Then_NoEntriesAreListed(string path)
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.iso";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+        const bool recursive = false;
+
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - create iso9660 image with directories and files
+            CreateIso9660WithDirectoriesAndFiles(mediaPath);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+            EntriesInfo entriesInfo = null;
+            fsDirCommand.EntriesRead += (_, args) =>
+            {
+                entriesInfo = args.EntriesInfo;
+            };
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is success with no entries
+            Assert.NotNull(result);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(entriesInfo);
+            Assert.Empty(entriesInfo.Entries);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("x*")]
+    [InlineData("test4*")]
+    [InlineData("dir1\\es*")]
+    public async Task When_ListingEntriesInExistingDirectoryWithPatternNotMatchingRecursively_Then_NoEntriesAreListed(string path)
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.iso";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+        const bool recursive = true;
+
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - create iso9660 image with directories and files
+            CreateIso9660WithDirectoriesAndFiles(mediaPath);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+            EntriesInfo entriesInfo = null;
+            fsDirCommand.EntriesRead += (_, args) =>
+            {
+                entriesInfo = args.EntriesInfo;
+            };
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is success with no file entries
+            Assert.NotNull(result);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(entriesInfo);
+            Assert.DoesNotContain(entriesInfo.Entries, entry => entry.Type == EntryType.File);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+    
+    [Theory]
+    [InlineData("x", true)]
+    [InlineData("x", false)]
+    [InlineData("test4", true)]
+    [InlineData("test4", false)]
+    [InlineData("dir1\\e", true)]
+    [InlineData("dir1\\e", false)]
+    public async Task When_ListingEntriesInNonExistingDirectory_Then_ErrorIsReturned(string path, bool recursive)
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.iso";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - create iso9660 image with directories and files
+            CreateIso9660WithDirectoriesAndFiles(mediaPath);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is faulted with path not found error
+            Assert.NotNull(result);
+            Assert.True(result.IsFaulted); 
+            Assert.IsType<PathNotFoundError>(result.Error);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+}

--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDirCommandWithLha.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDirCommandWithLha.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hst.Imager.Core.Commands;
+using Hst.Imager.Core.Models.FileSystems;
+using Hst.Imager.Core.PathComponents;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Hst.Imager.Core.Tests.CommandTests.FsCommandTests;
+
+public class GivenFsDirCommandWithLha
+{
+    [Theory]
+    [InlineData("", true)]
+    [InlineData("", false)]
+    [InlineData("*", true)]
+    [InlineData("*", false)]
+    [InlineData("test.txt", true)]
+    [InlineData("test.txt", false)]
+    [InlineData("test1", true)]
+    [InlineData("test1", false)]
+    [InlineData("test1\\t*", true)]
+    [InlineData("test1\\t*", false)]
+    [InlineData("test1\\test1.txt", true)]
+    [InlineData("test1\\test1.txt", false)]
+    [InlineData("test1\\test2", true)]
+    [InlineData("test1\\test2", false)]
+    [InlineData("test1\\test2\\*", true)]
+    [InlineData("test1\\test2\\*", false)]
+    public async Task When_ListingEntriesInExisting_Then_EntriesAreListed(string path, bool recursive)
+    {
+        // arrange - paths
+        var lhaPath = Path.Combine("TestData", "Lha", "amiga.lha");
+        var mediaPath = $"{Guid.NewGuid()}.lha";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+        
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - copy lha test data to media path
+            File.Copy(lhaPath, mediaPath, true);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+            EntriesInfo entriesInfo = null;
+            fsDirCommand.EntriesRead += (_, args) =>
+            {
+                entriesInfo = args.EntriesInfo;
+            };
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is success with one entry
+            Assert.NotNull(result);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(entriesInfo);
+            Assert.NotEmpty(entriesInfo.Entries);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("x*")]
+    [InlineData("test4*")]
+    [InlineData("test1\\e*")]
+    public async Task When_ListingEntriesInExistingDirectoryWithPatternNotMatching_Then_NoEntriesAreListed(string path)
+    {
+        // arrange - paths
+        var lhaPath = Path.Combine("TestData", "Lha", "amiga.lha");
+        var mediaPath = $"{Guid.NewGuid()}.lha";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+        const bool recursive = false;
+
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - copy lha test data to media path
+            File.Copy(lhaPath, mediaPath, true);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+            EntriesInfo entriesInfo = null;
+            fsDirCommand.EntriesRead += (_, args) =>
+            {
+                entriesInfo = args.EntriesInfo;
+            };
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is success with no entries
+            Assert.NotNull(result);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(entriesInfo);
+            Assert.Empty(entriesInfo.Entries);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("x*")]
+    [InlineData("test4*")]
+    [InlineData("test1\\es*")]
+    public async Task When_ListingEntriesInExistingDirectoryWithPatternNotMatchingRecursively_Then_NoEntriesAreListed(string path)
+    {
+        // arrange - paths
+        var lhaPath = Path.Combine("TestData", "Lha", "amiga.lha");
+        var mediaPath = $"{Guid.NewGuid()}.lha";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+        const bool recursive = true;
+
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - copy lha test data to media path
+            File.Copy(lhaPath, mediaPath, true);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+            EntriesInfo entriesInfo = null;
+            fsDirCommand.EntriesRead += (_, args) =>
+            {
+                entriesInfo = args.EntriesInfo;
+            };
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is success with no file entries
+            Assert.NotNull(result);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(entriesInfo);
+            Assert.DoesNotContain(entriesInfo.Entries, entry => entry.Type == EntryType.File);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+    
+    [Theory]
+    [InlineData("x", true)]
+    [InlineData("x", false)]
+    [InlineData("test4", true)]
+    [InlineData("test4", false)]
+    [InlineData("test1\\e", true)]
+    [InlineData("test1\\e", false)]
+    public async Task When_ListingEntriesInNonExistingDirectory_Then_ErrorIsReturned(string path, bool recursive)
+    {
+        // arrange - paths
+        var lhaPath = Path.Combine("TestData", "Lha", "amiga.lha");
+        var mediaPath = $"{Guid.NewGuid()}.lha";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - copy lha test data to media path
+            File.Copy(lhaPath, mediaPath, true);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is faulted with path not found error
+            Assert.NotNull(result);
+            Assert.True(result.IsFaulted); 
+            Assert.IsType<PathNotFoundError>(result.Error);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+}

--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDirCommandWithLocalDirectory.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDirCommandWithLocalDirectory.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Hst.Imager.Core.Commands;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Hst.Imager.Core.Tests.CommandTests.FsCommandTests;
+
+public class GivenFsDirCommandWithLocalDirectory
+{
+    [Fact]
+    public async Task When_ListingEntriesInNonExistingDirectory_Then_ErrorIsReturned()
+    {
+        // arrange - paths
+        var dirPath = $"local_{Guid.NewGuid()}";
+        const bool recursive = false;
+
+        // arrange - test command helper
+        var testCommandHelper = new TestCommandHelper();
+        
+        // arrange - create fs dir command
+        var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+            new List<IPhysicalDrive>(),
+            dirPath, recursive);
+
+        // act - execute fs dir command
+        var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+        // assert - result is faulted
+        Assert.NotNull(result);
+        Assert.True(result.IsFaulted);
+    }
+}

--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDirCommandWithLzx.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDirCommandWithLzx.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hst.Imager.Core.Commands;
+using Hst.Imager.Core.Models.FileSystems;
+using Hst.Imager.Core.PathComponents;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Hst.Imager.Core.Tests.CommandTests.FsCommandTests;
+
+public class GivenFsDirCommandWithLzx
+{
+    [Theory]
+    [InlineData("", true)]
+    [InlineData("", false)]
+    [InlineData("*", true)]
+    [InlineData("*", false)]
+    [InlineData("test.txt", true)]
+    [InlineData("test.txt", false)]
+    [InlineData("test1", true)]
+    [InlineData("test1", false)]
+    [InlineData("test1\\t*", true)]
+    [InlineData("test1\\t*", false)]
+    [InlineData("test1\\test1.txt", true)]
+    [InlineData("test1\\test1.txt", false)]
+    [InlineData("test1\\test2", true)]
+    [InlineData("test1\\test2", false)]
+    [InlineData("test1\\test2\\*", true)]
+    [InlineData("test1\\test2\\*", false)]
+    public async Task When_ListingEntriesInExisting_Then_EntriesAreListed(string path, bool recursive)
+    {
+        // arrange - paths
+        var lzxPath = Path.Combine("TestData", "Lzx", "amiga.lzx");
+        var mediaPath = $"{Guid.NewGuid()}.lzx";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+        
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - copy lzx test data to media path
+            File.Copy(lzxPath, mediaPath, true);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+            EntriesInfo entriesInfo = null;
+            fsDirCommand.EntriesRead += (_, args) =>
+            {
+                entriesInfo = args.EntriesInfo;
+            };
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is success with one entry
+            Assert.NotNull(result);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(entriesInfo);
+            Assert.NotEmpty(entriesInfo.Entries);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("x*")]
+    [InlineData("test4*")]
+    [InlineData("test1\\e*")]
+    public async Task When_ListingEntriesInExistingDirectoryWithPatternNotMatching_Then_NoEntriesAreListed(string path)
+    {
+        // arrange - paths
+        var lzxPath = Path.Combine("TestData", "Lzx", "amiga.lzx");
+        var mediaPath = $"{Guid.NewGuid()}.lzx";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+        const bool recursive = false;
+
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - copy lzx test data to media path
+            File.Copy(lzxPath, mediaPath, true);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+            EntriesInfo entriesInfo = null;
+            fsDirCommand.EntriesRead += (_, args) =>
+            {
+                entriesInfo = args.EntriesInfo;
+            };
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is success with no entries
+            Assert.NotNull(result);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(entriesInfo);
+            Assert.Empty(entriesInfo.Entries);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("x*")]
+    [InlineData("test4*")]
+    [InlineData("test1\\es*")]
+    public async Task When_ListingEntriesInExistingDirectoryWithPatternNotMatchingRecursively_Then_NoEntriesAreListed(string path)
+    {
+        // arrange - paths
+        var lzxPath = Path.Combine("TestData", "Lzx", "amiga.lzx");
+        var mediaPath = $"{Guid.NewGuid()}.lzx";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+        const bool recursive = true;
+
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - copy lzx test data to media path
+            File.Copy(lzxPath, mediaPath, true);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+            EntriesInfo entriesInfo = null;
+            fsDirCommand.EntriesRead += (_, args) =>
+            {
+                entriesInfo = args.EntriesInfo;
+            };
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is success with no file entries
+            Assert.NotNull(result);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(entriesInfo);
+            Assert.DoesNotContain(entriesInfo.Entries, entry => entry.Type == EntryType.File);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+    
+    [Theory]
+    [InlineData("x", true)]
+    [InlineData("x", false)]
+    [InlineData("test4", true)]
+    [InlineData("test4", false)]
+    [InlineData("test1\\e", true)]
+    [InlineData("test1\\e", false)]
+    public async Task When_ListingEntriesInNonExistingDirectory_Then_ErrorIsReturned(string path, bool recursive)
+    {
+        // arrange - paths
+        var lzxPath = Path.Combine("TestData", "Lzx", "amiga.lzx");
+        var mediaPath = $"{Guid.NewGuid()}.lzx";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - copy lzx test data to media path
+            File.Copy(lzxPath, mediaPath, true);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is faulted with path not found error
+            Assert.NotNull(result);
+            Assert.True(result.IsFaulted); 
+            Assert.IsType<PathNotFoundError>(result.Error);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+}

--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDirCommandWithRdbPfs3FormattedDisk.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDirCommandWithRdbPfs3FormattedDisk.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Hst.Imager.Core.Commands;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Hst.Imager.Core.Tests.CommandTests.FsCommandTests;
+
+public class GivenFsDirCommandWithRdbPfs3FormattedDisk
+{
+    [Fact]
+    public async Task When_ListingEntriesInNonExistingDirectory_Then_ErrorIsReturned()
+    {
+        // arrange - paths
+        var mediaPath = $"rdb_{Guid.NewGuid()}.vhd";
+        var dirPath = Path.Combine(mediaPath, "rdb", "1", Guid.NewGuid().ToString());
+        const bool recursive = false;
+
+        // arrange - test command helper
+        var testCommandHelper = new TestCommandHelper();
+
+        // arrange - create rdb disk
+        await TestHelper.CreatePfs3FormattedDisk(testCommandHelper, mediaPath);
+
+        // arrange - create fs dir command
+        var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+            new List<IPhysicalDrive>(),
+            dirPath, recursive);
+
+        // act - execute fs dir command
+        var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+        // assert - result is faulted with path not found error
+        Assert.NotNull(result);
+        Assert.True(result.IsFaulted); 
+        Assert.IsType<PathNotFoundError>(result.Error);
+    }
+}

--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDirCommandWithZip.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDirCommandWithZip.cs
@@ -1,0 +1,224 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hst.Imager.Core.Commands;
+using Hst.Imager.Core.Models.FileSystems;
+using Hst.Imager.Core.PathComponents;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Hst.Imager.Core.Tests.CommandTests.FsCommandTests;
+
+public class GivenFsDirCommandWithZip
+{
+    [Theory]
+    [InlineData("", true)]
+    [InlineData("", false)]
+    [InlineData("*", true)]
+    [InlineData("*", false)]
+    [InlineData("file1.txt", true)]
+    [InlineData("file1.txt", false)]
+    [InlineData("dir1", true)]
+    [InlineData("dir1", false)]
+    [InlineData("dir1\\t*", true)]
+    [InlineData("dir1\\t*", false)]
+    [InlineData("dir1\\test.txt", true)]
+    [InlineData("dir1\\test.txt", false)]
+    [InlineData("dir1\\dir2", true)]
+    [InlineData("dir1\\dir2", false)]
+    [InlineData("dir1\\dir2\\*", true)]
+    [InlineData("dir1\\dir2\\*", false)]
+    public async Task When_ListingEntriesInExisting_Then_EntriesAreListed(string path, bool recursive)
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.zip";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+        
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - create zip file with directories and files
+            CreateZipFileWithDirectoriesAndFiles(mediaPath);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+            EntriesInfo entriesInfo = null;
+            fsDirCommand.EntriesRead += (_, args) =>
+            {
+                entriesInfo = args.EntriesInfo;
+            };
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is success with one entry
+            Assert.NotNull(result);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(entriesInfo);
+            Assert.NotEmpty(entriesInfo.Entries);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("x*")]
+    [InlineData("test4*")]
+    [InlineData("dir1\\e*")]
+    public async Task When_ListingEntriesInExistingDirectoryWithPatternNotMatching_Then_NoEntriesAreListed(string path)
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.zip";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+        const bool recursive = false;
+
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - create zip file with directories and files
+            CreateZipFileWithDirectoriesAndFiles(mediaPath);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+            EntriesInfo entriesInfo = null;
+            fsDirCommand.EntriesRead += (_, args) =>
+            {
+                entriesInfo = args.EntriesInfo;
+            };
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is success with no entries
+            Assert.NotNull(result);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(entriesInfo);
+            Assert.Empty(entriesInfo.Entries);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("x*")]
+    [InlineData("test4*")]
+    [InlineData("dir1\\es*")]
+    public async Task When_ListingEntriesInExistingDirectoryWithPatternNotMatchingRecursively_Then_NoEntriesAreListed(string path)
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.zip";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+        const bool recursive = true;
+
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - create zip file with directories and files
+            CreateZipFileWithDirectoriesAndFiles(mediaPath);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+            EntriesInfo entriesInfo = null;
+            fsDirCommand.EntriesRead += (_, args) =>
+            {
+                entriesInfo = args.EntriesInfo;
+            };
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is success with no file entries
+            Assert.NotNull(result);
+            Assert.True(result.IsSuccess);
+            Assert.NotNull(entriesInfo);
+            Assert.DoesNotContain(entriesInfo.Entries, entry => entry.Type == EntryType.File);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+    
+    [Theory]
+    [InlineData("x", true)]
+    [InlineData("x", false)]
+    [InlineData("test4", true)]
+    [InlineData("test4", false)]
+    [InlineData("dir1\\e", true)]
+    [InlineData("dir1\\e", false)]
+    public async Task When_ListingEntriesInNonExistingDirectory_Then_ErrorIsReturned(string path, bool recursive)
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.zip";
+        var dirPath = Path.Combine(new[]{mediaPath}.Concat(MediaPath.GenericMediaPath.Split(path)).ToArray());
+
+        try
+        {
+            // arrange - test command helper
+            var testCommandHelper = new TestCommandHelper();
+
+            // arrange - create zip file with directories and files
+            CreateZipFileWithDirectoriesAndFiles(mediaPath);
+            
+            // arrange - create fs dir command
+            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
+                new List<IPhysicalDrive>(),
+                dirPath, recursive);
+
+            // act - execute fs dir command
+            var result = await fsDirCommand.Execute(CancellationToken.None);
+        
+            // assert - result is faulted with path not found error
+            Assert.NotNull(result);
+            Assert.True(result.IsFaulted); 
+            Assert.IsType<PathNotFoundError>(result.Error);
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+        }
+    }
+    
+    private void CreateZipFileWithDirectoriesAndFiles(string path)
+    {
+        using var stream = File.Open(path, FileMode.Create, FileAccess.ReadWrite);
+        using var zipArchive = new ZipArchive(stream, ZipArchiveMode.Create);
+        zipArchive.CreateEntry("file1.txt");
+        zipArchive.CreateEntry("file2.txt");
+        zipArchive.CreateEntry("dir1/file3.txt");
+        zipArchive.CreateEntry("dir1/test.txt");
+        zipArchive.CreateEntry("dir1/dir2/file4.txt");
+    }
+}

--- a/src/Hst.Imager.Core/Commands/CommandHelper.cs
+++ b/src/Hst.Imager.Core/Commands/CommandHelper.cs
@@ -1165,7 +1165,7 @@ namespace Hst.Imager.Core.Commands
 
             if (!Directory.Exists(path) && !allowNonExisting)
             {
-                return new Result<MediaResult>(new PathNotFoundError($"Media not '{path}' found", path));
+                return new Result<MediaResult>(new PathNotFoundError($"Path not found '{path}'", path));
             }
             
             return new Result<MediaResult>(new MediaResult

--- a/src/Hst.Imager.Core/Commands/DirectoryEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/DirectoryEntryIterator.cs
@@ -1,4 +1,5 @@
-﻿using Hst.Imager.Core.Helpers;
+﻿using Hst.Core;
+using Hst.Imager.Core.Helpers;
 using Hst.Imager.Core.Models;
 
 namespace Hst.Imager.Core.Commands;
@@ -9,10 +10,10 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Caching;
 using System.Threading.Tasks;
-using Hst.Amiga.DataTypes.UaeFsDbs;
-using Hst.Amiga.DataTypes.UaeMetafiles;
-using Hst.Imager.Core.PathComponents;
-using Hst.Imager.Core.UaeMetadatas;
+using Amiga.DataTypes.UaeFsDbs;
+using Amiga.DataTypes.UaeMetafiles;
+using PathComponents;
+using UaeMetadatas;
 using Entry = Models.FileSystems.Entry;
 
 public class DirectoryEntryIterator : IEntryIterator
@@ -42,13 +43,13 @@ public class DirectoryEntryIterator : IEntryIterator
         dirPath = Directory.Exists(rootPath) ? rootPath : Path.GetDirectoryName(rootPath);
     }
 
-    public Task Initialize()
+    public Task<Result> Initialize()
     {
         IsSingleFileEntryNext = File.Exists(this.rootPath);
         
         if (!Directory.Exists(dirPath))
         {
-            throw new DirectoryNotFoundException(dirPath);
+            return Task.FromResult(new Result(new PathNotFoundError("Path not found '{dirPath}'", dirPath)));
         }
         
         var pathComponents = GetPathComponents(rootPath);
@@ -62,7 +63,7 @@ public class DirectoryEntryIterator : IEntryIterator
         pathComponentMatcher = new PathComponentMatcher(usePattern ? pathComponents : [], 
             isFile: IsSingleFileEntryNext, recursive: recursive);
         
-        return Task.CompletedTask;
+        return Task.FromResult(new Result());
     }
 
     public string[] PathComponents => rootPathComponents;

--- a/src/Hst.Imager.Core/Commands/FsCopyCommand.cs
+++ b/src/Hst.Imager.Core/Commands/FsCopyCommand.cs
@@ -182,8 +182,10 @@ public class FsCopyCommand(
         var directoryEntryIterator = await GetDirectoryEntryIterator(path, recursive);
         if (directoryEntryIterator != null && directoryEntryIterator.IsSuccess)
         {
-            await directoryEntryIterator.Value.Initialize();
-            return new Result<IEntryIterator>(directoryEntryIterator.Value);
+            var initializeResult = await directoryEntryIterator.Value.Initialize();
+            return initializeResult.IsSuccess
+                ? new Result<IEntryIterator>(directoryEntryIterator.Value)
+                : new Result<IEntryIterator>(initializeResult.Error);
         }
 
         // path is not a directory, so must be a file
@@ -205,8 +207,10 @@ public class FsCopyCommand(
             var fileEntryIterator = await GetFileEntryIterator(path, recursive);
             if (fileEntryIterator != null && fileEntryIterator.IsSuccess)
             {
-                await fileEntryIterator.Value.Initialize();
-                return new Result<IEntryIterator>(fileEntryIterator.Value);
+                var initializeResult = await fileEntryIterator.Value.Initialize();
+                return initializeResult.IsSuccess
+                    ? new Result<IEntryIterator>(fileEntryIterator.Value)
+                    : new Result<IEntryIterator>(initializeResult.Error);
             }
         }
         
@@ -222,8 +226,10 @@ public class FsCopyCommand(
         {
             var rootPathComponents = entryIteratorFileSystemPathComponents;
             var entryIterator = entryWriter.CreateEntryIterator(rootPathComponents, recursive);
-            await entryIterator.Initialize();
-            return new Result<IEntryIterator>(entryIterator);
+            var initializeResult = await entryIterator.Initialize();
+            return initializeResult.IsSuccess
+                ? new Result<IEntryIterator>(entryIterator)
+                : new Result<IEntryIterator>(initializeResult.Error);
         }
         
         if (mediaResult.Value.MediaPath == entryWriter.MediaPath &&
@@ -232,16 +238,20 @@ public class FsCopyCommand(
         {
             var rootPathComponents = entryIteratorFileSystemPathComponents.Skip(2).ToArray();
             var entryIterator = entryWriter.CreateEntryIterator(rootPathComponents, recursive);
-            await entryIterator.Initialize();
-            return new Result<IEntryIterator>(entryIterator);
+            var initializeResult = await entryIterator.Initialize();
+            return initializeResult.IsSuccess
+                ? new Result<IEntryIterator>(entryIterator)
+                : new Result<IEntryIterator>(initializeResult.Error);
         }
 
         // floppy or disk entry iterator
         var diskEntryIterator = await GetDiskEntryIterator(mediaResult.Value, recursive, false, 100 * 1024 * 1024, 512);
         if (diskEntryIterator != null && diskEntryIterator.IsSuccess)
         {
-            await diskEntryIterator.Value.Initialize();
-            return new Result<IEntryIterator>(diskEntryIterator.Value);
+            var initializeResult = await diskEntryIterator.Value.Initialize();
+            return initializeResult.IsSuccess
+                ? new Result<IEntryIterator>(diskEntryIterator.Value)
+                : new Result<IEntryIterator>(initializeResult.Error);
         }
 
         return new Result<IEntryIterator>(new Error($"Unsupported path '{path}'"));

--- a/src/Hst.Imager.Core/Commands/FsExtractCommand.cs
+++ b/src/Hst.Imager.Core/Commands/FsExtractCommand.cs
@@ -209,48 +209,60 @@ public class FsExtractCommand(
         var zipEntryIteratorResult = await GetZipEntryIterator(mediaResult.Value, recursive);
         if (zipEntryIteratorResult != null && zipEntryIteratorResult.IsSuccess)
         {
-            await zipEntryIteratorResult.Value.Initialize();
-            return new Result<IEntryIterator>(zipEntryIteratorResult.Value);
+            var initializeResult = await zipEntryIteratorResult.Value.Initialize();
+            return initializeResult.IsSuccess
+                ? new Result<IEntryIterator>(zipEntryIteratorResult.Value)
+                : new Result<IEntryIterator>(initializeResult.Error);
         }
 
         // lha
         var lhaEntryIteratorResult = await GetLhaEntryIterator(mediaResult.Value, recursive);
         if (lhaEntryIteratorResult != null && lhaEntryIteratorResult.IsSuccess)
         {
-            await lhaEntryIteratorResult.Value.Initialize();
-            return new Result<IEntryIterator>(lhaEntryIteratorResult.Value);
+            var initializeResult = await lhaEntryIteratorResult.Value.Initialize();
+            return initializeResult.IsSuccess
+                ? new Result<IEntryIterator>(lhaEntryIteratorResult.Value)
+                : new Result<IEntryIterator>(initializeResult.Error);
         }
 
         // lzx
         var lzxEntryIteratorResult = await GetLzxEntryIterator(mediaResult.Value, recursive);
         if (lzxEntryIteratorResult != null && lzxEntryIteratorResult.IsSuccess)
         {
-            await lzxEntryIteratorResult.Value.Initialize();
-            return new Result<IEntryIterator>(lzxEntryIteratorResult.Value);
+            var initializeResult = await lzxEntryIteratorResult.Value.Initialize();
+            return initializeResult.IsSuccess
+                ? new Result<IEntryIterator>(lzxEntryIteratorResult.Value)
+                : new Result<IEntryIterator>(initializeResult.Error);
         }
         
         // lzw
         var lzwEntryIteratorResult = await GetLzwEntryIterator(mediaResult.Value);
         if (lzwEntryIteratorResult != null && lzwEntryIteratorResult.IsSuccess)
         {
-            await lzwEntryIteratorResult.Value.Initialize();
-            return new Result<IEntryIterator>(lzwEntryIteratorResult.Value);
+            var initializeResult = await lzwEntryIteratorResult.Value.Initialize();
+            return initializeResult.IsSuccess
+                ? new Result<IEntryIterator>(lzwEntryIteratorResult.Value)
+                : new Result<IEntryIterator>(initializeResult.Error);
         }
 
         // adf
         var adfEntryIteratorResult = await GetAdfEntryIterator(mediaResult.Value, recursive);
         if (adfEntryIteratorResult != null && adfEntryIteratorResult.IsSuccess)
         {
-            await adfEntryIteratorResult.Value.Initialize();
-            return new Result<IEntryIterator>(adfEntryIteratorResult.Value);
+            var initializeResult = await adfEntryIteratorResult.Value.Initialize();
+            return initializeResult.IsSuccess
+                ? new Result<IEntryIterator>(adfEntryIteratorResult.Value)
+                : new Result<IEntryIterator>(initializeResult.Error);
         }
 
         // iso
         var iso9660EntryIteratorResult = await GetIso9660EntryIterator(mediaResult.Value, recursive);
         if (iso9660EntryIteratorResult != null && iso9660EntryIteratorResult.IsSuccess)
         {
-            await iso9660EntryIteratorResult.Value.Initialize();
-            return new Result<IEntryIterator>(iso9660EntryIteratorResult.Value);
+            var initializeResult = await iso9660EntryIteratorResult.Value.Initialize();
+            return initializeResult.IsSuccess
+                ? new Result<IEntryIterator>(iso9660EntryIteratorResult.Value)
+                : new Result<IEntryIterator>(initializeResult.Error);
         }
 
         return new Result<IEntryIterator>(new Error($"File system at path '{path}' not supported"));

--- a/src/Hst.Imager.Core/Commands/IEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/IEntryIterator.cs
@@ -1,8 +1,9 @@
-﻿using Hst.Imager.Core.Models;
+﻿using Hst.Core;
+using Hst.Imager.Core.Models;
 
 namespace Hst.Imager.Core.Commands;
 
-using Hst.Imager.Core.UaeMetadatas;
+using UaeMetadatas;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -10,7 +11,7 @@ using Entry = Models.FileSystems.Entry;
 
 public interface IEntryIterator : IDisposable
 {
-    Task Initialize();
+    Task<Result> Initialize();
     string[] PathComponents { get; }
     string[] DirPathComponents { get; }
     

--- a/src/Hst.Imager.Core/Commands/LzwArchiveEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/LzwArchiveEntryIterator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Hst.Core;
 using Hst.Imager.Core.Models;
 
 namespace Hst.Imager.Core.Commands;
@@ -35,9 +36,9 @@ public class LzwArchiveEntryIterator : IEntryIterator
     {
     }
 
-    public Task Initialize()
+    public Task<Result> Initialize()
     {
-        return Task.CompletedTask;
+        return Task.FromResult(new Result());
     }
 
     public string[] PathComponents { get; }

--- a/src/Hst.Imager.Core/Commands/PathComponentHelper.cs
+++ b/src/Hst.Imager.Core/Commands/PathComponentHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Hst.Imager.Core.Models.FileSystems;
 
 namespace Hst.Imager.Core.Commands;
@@ -54,4 +55,47 @@ public static class PathComponentHelper
 
         return fullPathComponents;
     }
+    
+    /// <summary>
+    /// Has wildcard examines if path component contains a * wildcard.
+    /// </summary>
+    /// <param name="pathComponent"></param>
+    /// <returns>True, if path component contains a * wildcard. Otherwise, false.</returns>
+    public static bool HasWildcard(string pathComponent) => 
+        pathComponent.Length > 0 && pathComponent.Contains('*', StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Matches root path components with entry path components. Last path component supports wildcard.
+    /// </summary>
+    /// <param name="rootPathComponents">Root path components.</param>
+    /// <param name="entryPathComponents">Entry path components.</param>
+    /// <returns>Path component match indicating if root path components matches entry path components together with matching path components.</returns>
+    public static PathComponentMatch MatchPathComponents(string[] rootPathComponents, string[] entryPathComponents)
+    {
+        // return all entry path components as match, if root path components is empty or
+        // root path components equal entry path components
+        if (rootPathComponents.Length == 0 ||
+            rootPathComponents.SequenceEqual(entryPathComponents))
+        {
+            return new PathComponentMatch(true, rootPathComponents);
+        }
+
+        var rootPathHasWildcard = HasWildcard(rootPathComponents[^1]);
+        var rootPathComponentsWithoutWildcard = rootPathHasWildcard
+            ? rootPathComponents.Take(rootPathComponents.Length - 1).ToArray()
+            : rootPathComponents;
+        if (rootPathHasWildcard && rootPathComponentsWithoutWildcard.SequenceEqual(
+                entryPathComponents.Take(rootPathComponentsWithoutWildcard.Length)))
+        {
+            return new PathComponentMatch(true, rootPathComponentsWithoutWildcard);
+        }
+
+        // return root path components as match, if they are equal the beginning of entry path components
+        // otherwise return no match
+        return rootPathComponents.SequenceEqual(entryPathComponents.Take(rootPathComponents.Length))
+            ? new PathComponentMatch(true, rootPathComponents)
+            : new PathComponentMatch(false, []);
+    }
 }
+
+public record PathComponentMatch(bool Success, string[] MatchingPathComponents);

--- a/src/Hst.Imager.Core/Commands/UdfEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/UdfEntryIterator.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using DiscUtils.Udf;
+using Hst.Core;
 using Hst.Imager.Core.Helpers;
 using Hst.Imager.Core.Models;
 using Hst.Imager.Core.Models.FileSystems;
@@ -63,9 +64,9 @@ public class UdfEntryIterator : IEntryIterator
 
     public void Dispose() => Dispose(true);
 
-    public Task Initialize()
+    public Task<Result> Initialize()
     {
-        return Task.CompletedTask;
+        return Task.FromResult(new Result());
     }
 
     public string[] PathComponents => rootPathComponents;

--- a/src/Hst.Imager.Core/PathComponents/PathComponentMatcher.cs
+++ b/src/Hst.Imager.Core/PathComponents/PathComponentMatcher.cs
@@ -30,7 +30,7 @@ public class PathComponentMatcher
         var lastPathComponent = hasPathComponents ? pathComponents[^1].Trim() : string.Empty;
 
         // uses pattern is only set if the last path component exists, is more than 1 character long and contains a wildcard
-        var hasWildcard = lastPathComponent.Contains("*", StringComparison.OrdinalIgnoreCase);
+        var hasWildcard = PathComponentHelper.HasWildcard(lastPathComponent);
 
         UsesPattern = lastPathComponent.Length > 1 && hasWildcard;
         PathComponents = isFile || hasWildcard


### PR DESCRIPTION
This PR updates initialize for all entry iterators to check existing paths and return error is path not found. Listing entries with fs dir would entries that didn't make sense, if the path didn't exist. The change covers fs dir, fs copy and fs extract commands, which will now return a path not found error, if the path doesn't exist.

At the same time disposing iso, lha, zip streams have been fixed.