### PR TITLE
Fix linux physical disk dispose with 100ms delay

### DIFF
--- a/src/Hst.Imager.Core/PhysicalDrives/GenericPhysicalDrive.cs
+++ b/src/Hst.Imager.Core/PhysicalDrives/GenericPhysicalDrive.cs
@@ -77,6 +77,7 @@ namespace Hst.Imager.Core.PhysicalDrives
             {
                 stream?.Close();
                 stream?.Dispose();
+                Task.Delay(100).GetAwaiter().GetResult();
             }
 
             IsDisposed = true;


### PR DESCRIPTION
This PR fixes Linux physical disk dispose by adding a 100ms delay after closing and disposing. The issue occurs when running a script that executes multiple commands accessing same physical disk. The 100ms delay allows Linux operating system to close physical disk access before being opened again when executing next command.