### PR TITLE
Fix rdb part import typo in readme. Add comment to linux generic physical disk dispose

### DIFF
--- a/src/Hst.Imager.ConsoleApp/readme.md
+++ b/src/Hst.Imager.ConsoleApp/readme.md
@@ -1103,9 +1103,9 @@ Example of displaying usage for importing a partition to Rigid Disk Block:
 hst.imager rdb part import
 ```
 
-Example of importing partition from dh0.hdf hard file with dos type PDS3 and device name DH0 to Rigid Disk Block in a 4GB vhd image file:
+Example of importing partition from dh0.hdf hard file with device name DH0 and dos type PDS3 to Rigid Disk Block in a 4GB vhd image file:
 ```
-hst.imager rdb part import dh0.hdf 4gb.vhd PDS3 DH0
+hst.imager rdb part import dh0.hdf 4gb.vhd DH0 PDS3
 ```
 
 ### Kill partition in Rigid Disk Block

--- a/src/Hst.Imager.Core/PhysicalDrives/GenericPhysicalDrive.cs
+++ b/src/Hst.Imager.Core/PhysicalDrives/GenericPhysicalDrive.cs
@@ -77,6 +77,7 @@ namespace Hst.Imager.Core.PhysicalDrives
             {
                 stream?.Close();
                 stream?.Dispose();
+                // linux needs a short delay to ensure stream is disposed before continuing
                 Task.Delay(100).GetAwaiter().GetResult();
             }
 


### PR DESCRIPTION
This PR fixes a typo in rdb part import readme and adds a comment about why the 100ms delay if required in generic physical disk dispose.