### PR TITLE
Add mklink command to create links in pfs3 and ffs file systems

### DIFF
--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsMkDirCommandWithAdf.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsMkDirCommandWithAdf.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Hst.Amiga.FileSystems;
+using Hst.Imager.Core.Commands;
 using Hst.Imager.Core.Commands.FsCommands;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -186,9 +187,10 @@ public class GivenFsMkDirCommandWithAdf
             // act - execute fs mkdir command
             var result = await fsMkDirCommand.Execute(CancellationToken.None);
             
-            // assert - error is returned
+            // assert - error is returned and is path exists error
             Assert.False(result.IsSuccess);
             Assert.True(result.IsFaulted);
+            Assert.IsType<PathExistsError>(result.Error);
         }
         finally
         {

--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsMkLinkCommand.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsMkLinkCommand.cs
@@ -153,7 +153,7 @@ public class GivenFsMkLinkCommand
         Assert.Equal("file.txt", linkEntry.LinkPath);
     }
     
-        [Fact]
+    [Fact]
     public async Task When_CreatingLinkToDirOnDos3Partition_Then_LinkIsCreated()
     {
         // arrange - paths
@@ -199,6 +199,103 @@ public class GivenFsMkLinkCommand
         // assert - link directory contains 1 entry
         entries = (await RdbTestHelper.GetEntriesFromFileSystemVolume(commandHelper, mediaPath,
             0, ["link"])).ToList();
+
+        // assert - file.txt entry exist and is a file type
+        var fileEntry = entries.FirstOrDefault(e => e.Name == "file.txt");
+        Assert.NotNull(fileEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.File,  fileEntry.Type);
+    }
+    
+    [Fact]
+    public async Task When_CreatingLinkToFileOnDos3Adf_Then_LinkIsCreated()
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.adf";
+        var fromPath = Path.Combine(mediaPath, "link.txt");
+        const string toPath = "file.txt";
+        
+        // arrange - create test command helper
+        using var commandHelper = new TestCommandHelper();
+
+        // arrange - create media
+        commandHelper.AddTestMedia(mediaPath, Amiga.FloppyDiskConstants.DoubleDensity.Size);
+        await AdfTestHelper.CreateFormattedAdfDisk(commandHelper, mediaPath);
+        
+        // arrange - create file.txt file
+        await AdfTestHelper.CreateFile(commandHelper, mediaPath, ["file.txt"]);
+        
+        // arrange - create fs mklink command
+        var command = new FsMkLinkCommand(new NullLogger<FsMkLinkCommand>(), commandHelper, [], fromPath,
+            toPath);
+
+        // act - execute fs mklink command
+        var result = await command.Execute(CancellationToken.None);
+
+        // assert - fs mklink command succeeded
+        Assert.True(result.IsSuccess);
+        
+        // assert - root directory contains 2 entries
+        var entries = (await AdfTestHelper.GetEntriesFromFileSystemVolume(commandHelper, mediaPath, [])).ToList();
+        Assert.Equal(2, entries.Count);
+        
+        // assert - file.txt entry exist and is a file
+        var fileEntry = entries.FirstOrDefault(e => e.Name == "file.txt");
+        Assert.NotNull(fileEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.File,  fileEntry.Type);
+        
+        // assert - link.txt entry exist, is a file link type and has link path to file.txt
+        var linkEntry = entries.FirstOrDefault(e => e.Name == "link.txt");
+        Assert.NotNull(linkEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.FileLink,  linkEntry.Type);
+        Assert.Equal("file.txt", linkEntry.LinkPath);
+    }
+    
+    [Fact]
+    public async Task When_CreatingLinkToDirOnDos3Adf_Then_LinkIsCreated()
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.adf";
+        var fromPath = Path.Combine(mediaPath, "link");
+        const string toPath = "dir";
+        
+        // arrange - create test command helper
+        using var commandHelper = new TestCommandHelper();
+
+        // arrange - create media
+        commandHelper.AddTestMedia(mediaPath, Amiga.FloppyDiskConstants.DoubleDensity.Size);
+        await AdfTestHelper.CreateFormattedAdfDisk(commandHelper, mediaPath);
+        
+        // arrange - create file.txt file
+        await AdfTestHelper.CreateFile(commandHelper, mediaPath, ["dir", "file.txt"]);
+        
+        // arrange - create fs mklink command
+        var command = new FsMkLinkCommand(new NullLogger<FsMkLinkCommand>(), commandHelper, [], fromPath,
+            toPath);
+
+        // act - execute fs mklink command
+        var result = await command.Execute(CancellationToken.None);
+
+        // assert - fs mklink command succeeded
+        Assert.True(result.IsSuccess);
+        
+        // assert - root directory contains 2 entries
+        var entries = (await AdfTestHelper.GetEntriesFromFileSystemVolume(commandHelper, mediaPath, [])).ToList();
+        Assert.Equal(2, entries.Count);
+        
+        // assert - dir entry exist and is a dir
+        var dirEntry = entries.FirstOrDefault(e => e.Name == "dir");
+        Assert.NotNull(dirEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.Dir,  dirEntry.Type);
+        
+        // assert - link entry exist, is a dir link type and has link path to dir
+        var linkEntry = entries.FirstOrDefault(e => e.Name == "link");
+        Assert.NotNull(linkEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.DirLink,  linkEntry.Type);
+        Assert.Equal("dir", linkEntry.LinkPath);
+        
+        // assert - link directory contains 1 entry
+        entries = (await AdfTestHelper.GetEntriesFromFileSystemVolume(commandHelper, mediaPath,
+            ["link"])).ToList();
 
         // assert - file.txt entry exist and is a file type
         var fileEntry = entries.FirstOrDefault(e => e.Name == "file.txt");

--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsMkLinkCommand.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsMkLinkCommand.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hst.Core.Extensions;
+using Hst.Imager.Core.Commands.FsCommands;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Hst.Imager.Core.Tests.CommandTests.FsCommandTests;
+
+public class GivenFsMkLinkCommand
+{
+    [Fact]
+    public async Task When_CreatingLinkToFileOnPfs3Partition_Then_LinkIsCreated()
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.vhd";
+        var fromPath = Path.Combine(mediaPath, "rdb", "1", "link.txt");
+        const string toPath = "file.txt";
+        
+        // arrange - create test command helper
+        using var commandHelper = new TestCommandHelper();
+
+        // arrange - create media
+        commandHelper.AddTestMedia(mediaPath, 0);
+        await TestHelper.CreatePfs3FormattedDisk(commandHelper, mediaPath, 100.MB().ToSectorSize());
+        
+        // arrange - create file.txt file
+        await RdbTestHelper.CreateFile(commandHelper, mediaPath, ["file.txt"]);
+        
+        // arrange - create fs mklink command
+        var command = new FsMkLinkCommand(new NullLogger<FsMkLinkCommand>(), commandHelper, [], fromPath,
+            toPath);
+
+        // act - execute fs mklink command
+        var result = await command.Execute(CancellationToken.None);
+
+        // assert - fs mklink command succeeded
+        Assert.True(result.IsSuccess);
+        
+        // assert - root directory contains 2 entries
+        var entries = (await RdbTestHelper.GetEntriesFromFileSystemVolume(commandHelper, mediaPath, 0, [])).ToList();
+        Assert.Equal(2, entries.Count);
+        
+        // assert - file.txt entry exist and is a file
+        var fileEntry = entries.FirstOrDefault(e => e.Name == "file.txt");
+        Assert.NotNull(fileEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.File,  fileEntry.Type);
+        
+        // assert - link.txt entry exist, is a file link type and has link path to file.txt
+        var linkEntry = entries.FirstOrDefault(e => e.Name == "link.txt");
+        Assert.NotNull(linkEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.FileLink,  linkEntry.Type);
+        Assert.Equal("file.txt", linkEntry.LinkPath);
+    }
+
+    [Fact]
+    public async Task When_CreatingLinkToDirOnPfs3Partition_Then_LinkIsCreated()
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.vhd";
+        var fromPath = Path.Combine(mediaPath, "rdb", "1", "link");
+        const string toPath = "dir";
+        
+        // arrange - create test command helper
+        using var commandHelper = new TestCommandHelper();
+
+        // arrange - create media
+        commandHelper.AddTestMedia(mediaPath, 0);
+        await TestHelper.CreatePfs3FormattedDisk(commandHelper, mediaPath, 100.MB().ToSectorSize());
+        
+        // arrange - create file.txt file
+        await RdbTestHelper.CreateFile(commandHelper, mediaPath, ["dir", "file.txt"]);
+        
+        // arrange - create fs mklink command
+        var command = new FsMkLinkCommand(new NullLogger<FsMkLinkCommand>(), commandHelper, [], fromPath,
+            toPath);
+
+        // act - execute fs mklink command
+        var result = await command.Execute(CancellationToken.None);
+
+        // assert - fs mklink command succeeded
+        Assert.True(result.IsSuccess);
+        
+        // assert - root directory contains 2 entries
+        var entries = (await RdbTestHelper.GetEntriesFromFileSystemVolume(commandHelper, mediaPath, 0, [])).ToList();
+        Assert.Equal(2, entries.Count);
+        
+        // assert - dir entry exist and is a dir
+        var dirEntry = entries.FirstOrDefault(e => e.Name == "dir");
+        Assert.NotNull(dirEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.Dir,  dirEntry.Type);
+        
+        // assert - link entry exist, is a dir link type and has link path to dir
+        var linkEntry = entries.FirstOrDefault(e => e.Name == "link");
+        Assert.NotNull(linkEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.DirLink,  linkEntry.Type);
+        Assert.Equal("dir", linkEntry.LinkPath);
+        
+        // assert - link directory contains 1 entry
+        entries = (await RdbTestHelper.GetEntriesFromFileSystemVolume(commandHelper, mediaPath,
+            0, ["link"])).ToList();
+
+        // assert - file.txt entry exist and is a file type
+        var fileEntry = entries.FirstOrDefault(e => e.Name == "file.txt");
+        Assert.NotNull(fileEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.File,  fileEntry.Type);
+    }
+    
+    [Fact]
+    public async Task When_CreatingLinkToFileOnDos3Partition_Then_LinkIsCreated()
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.vhd";
+        var fromPath = Path.Combine(mediaPath, "rdb", "1", "link.txt");
+        const string toPath = "file.txt";
+        
+        // arrange - create test command helper
+        using var commandHelper = new TestCommandHelper();
+
+        // arrange - create media
+        commandHelper.AddTestMedia(mediaPath, 0);
+        await TestHelper.CreateDos3FormattedDisk(commandHelper, mediaPath, 100.MB().ToSectorSize());
+        
+        // arrange - create file.txt file
+        await RdbTestHelper.CreateFile(commandHelper, mediaPath, ["file.txt"]);
+        
+        // arrange - create fs mklink command
+        var command = new FsMkLinkCommand(new NullLogger<FsMkLinkCommand>(), commandHelper, [], fromPath,
+            toPath);
+
+        // act - execute fs mklink command
+        var result = await command.Execute(CancellationToken.None);
+
+        // assert - fs mklink command succeeded
+        Assert.True(result.IsSuccess);
+        
+        // assert - root directory contains 2 entries
+        var entries = (await RdbTestHelper.GetEntriesFromFileSystemVolume(commandHelper, mediaPath, 0, [])).ToList();
+        Assert.Equal(2, entries.Count);
+        
+        // assert - file.txt entry exist and is a file
+        var fileEntry = entries.FirstOrDefault(e => e.Name == "file.txt");
+        Assert.NotNull(fileEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.File,  fileEntry.Type);
+        
+        // assert - link.txt entry exist, is a file link type and has link path to file.txt
+        var linkEntry = entries.FirstOrDefault(e => e.Name == "link.txt");
+        Assert.NotNull(linkEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.FileLink,  linkEntry.Type);
+        Assert.Equal("file.txt", linkEntry.LinkPath);
+    }
+    
+        [Fact]
+    public async Task When_CreatingLinkToDirOnDos3Partition_Then_LinkIsCreated()
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.vhd";
+        var fromPath = Path.Combine(mediaPath, "rdb", "1", "link");
+        const string toPath = "dir";
+        
+        // arrange - create test command helper
+        using var commandHelper = new TestCommandHelper();
+
+        // arrange - create media
+        commandHelper.AddTestMedia(mediaPath, 0);
+        await TestHelper.CreateDos3FormattedDisk(commandHelper, mediaPath, 100.MB().ToSectorSize());
+        
+        // arrange - create file.txt file
+        await RdbTestHelper.CreateFile(commandHelper, mediaPath, ["dir", "file.txt"]);
+        
+        // arrange - create fs mklink command
+        var command = new FsMkLinkCommand(new NullLogger<FsMkLinkCommand>(), commandHelper, [], fromPath,
+            toPath);
+
+        // act - execute fs mklink command
+        var result = await command.Execute(CancellationToken.None);
+
+        // assert - fs mklink command succeeded
+        Assert.True(result.IsSuccess);
+        
+        // assert - root directory contains 2 entries
+        var entries = (await RdbTestHelper.GetEntriesFromFileSystemVolume(commandHelper, mediaPath, 0, [])).ToList();
+        Assert.Equal(2, entries.Count);
+        
+        // assert - dir entry exist and is a dir
+        var dirEntry = entries.FirstOrDefault(e => e.Name == "dir");
+        Assert.NotNull(dirEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.Dir,  dirEntry.Type);
+        
+        // assert - link entry exist, is a dir link type and has link path to dir
+        var linkEntry = entries.FirstOrDefault(e => e.Name == "link");
+        Assert.NotNull(linkEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.DirLink,  linkEntry.Type);
+        Assert.Equal("dir", linkEntry.LinkPath);
+        
+        // assert - link directory contains 1 entry
+        entries = (await RdbTestHelper.GetEntriesFromFileSystemVolume(commandHelper, mediaPath,
+            0, ["link"])).ToList();
+
+        // assert - file.txt entry exist and is a file type
+        var fileEntry = entries.FirstOrDefault(e => e.Name == "file.txt");
+        Assert.NotNull(fileEntry);
+        Assert.Equal(Amiga.FileSystems.EntryType.File,  fileEntry.Type);
+    }
+}

--- a/src/Hst.Imager.Core.Tests/TestHelper.cs
+++ b/src/Hst.Imager.Core.Tests/TestHelper.cs
@@ -106,6 +106,24 @@ namespace Hst.Imager.Core.Tests
 
             await Pfs3Formatter.FormatPartition(stream, partitionBlock, "Workbench");
         }
+        
+        public static async Task CreateDos3FormattedDisk(TestCommandHelper testCommandHelper, string path, 
+            long diskSize = 10 * 1024 * 1024)
+        {
+            var mediaResult = await testCommandHelper.GetWritableFileMedia(path, size: diskSize, create: true);
+            using var media = mediaResult.Value;
+            var stream = media.Stream;
+
+            var rigidDiskBlock = RigidDiskBlock.Create(diskSize.ToUniversalSize());
+
+            rigidDiskBlock.AddFileSystem(Dos3DosType, FastFileSystemDos3Bytes)
+                .AddPartition("DH0", bootable: true);
+            await RigidDiskBlockWriter.WriteBlock(rigidDiskBlock, stream);
+
+            var partitionBlock = rigidDiskBlock.PartitionBlocks.First();
+
+            await FastFileSystemFormatter.FormatPartition(stream, partitionBlock, "Workbench");
+        }
 
         public static async Task<Pfs3Volume> MountPfs3Volume(Stream stream)
         {

--- a/src/Hst.Imager.Core/Commands/AmigaVolumeEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/AmigaVolumeEntryIterator.cs
@@ -204,8 +204,14 @@ public class AmigaVolumeEntryIterator(
                 { Constants.EntryPropertyNames.ProtectionBits, ((int)entry.ProtectionBits ^ 0xf).ToString() }
             };
 
+            if ((entry.Type == EntryType.DirLink || entry.Type == EntryType.FileLink) &&
+                !string.IsNullOrEmpty(entry.LinkPath))
+            {
+                properties.Add(Constants.EntryPropertyNames.Link, entry.LinkPath);
+            }
+            
             var iteratorEntry = EntryIteratorFunctions.CreateEntry(mediaPath, DirPathComponents,
-                recursive, entryPath, entryPath, isDir, entry.Date, entry.Size,
+                recursive, entryPath, entryPath, entry.Type, entry.Date, entry.Size,
                 attributes, properties, dirAttributes);
 
             // skip if no entry was created or entry is a file and is not valid

--- a/src/Hst.Imager.Core/Commands/AmigaVolumeEntryWriter.cs
+++ b/src/Hst.Imager.Core/Commands/AmigaVolumeEntryWriter.cs
@@ -257,8 +257,12 @@ public class AmigaVolumeEntryWriter(
         
         IEnumerable<Hst.Amiga.FileSystems.Entry> entries = (await fileSystemVolume.ListEntries()).ToList();
 
-        var dirEntry = entries.FirstOrDefault(x =>
-            x.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && x.Type == EntryType.Dir);
+        var dirEntry = entries.FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+        if (dirEntry != null && dirEntry.Type != EntryType.Dir)
+        {
+            return new Result(new PathExistsError($"Path already exists with same name '{string.Join("/", fullPathComponents)}'"));
+        }
         
         if (dirEntry == null)
         {

--- a/src/Hst.Imager.Core/Commands/FsCommandBase.cs
+++ b/src/Hst.Imager.Core/Commands/FsCommandBase.cs
@@ -43,15 +43,16 @@ public abstract partial class FsCommandBase : CommandBase
         this.physicalDrives = physicalDrives;
     }
     
-    protected async Task<bool> IsAdfMedia(MediaResult mediaResult)
+    protected async Task<bool> IsAdfMedia(MediaResult resolvedMedia)
     {
-        // return false, if media file doesnt exist
-        if (!File.Exists(mediaResult.MediaPath))
+        var mediaResult = await commandHelper.GetReadableFileMedia(resolvedMedia.MediaPath);
+        if (mediaResult.IsFaulted)
         {
             return false;
         }
 
-        await using var stream = File.OpenRead(mediaResult.MediaPath);
+        using var media = mediaResult.Value;
+        var stream = media.Stream;
 
         stream.Seek(0, SeekOrigin.Begin);
         var sectorBytes = await stream.ReadBytes(512);

--- a/src/Hst.Imager.Core/Commands/FsCommands/FsMkLinkCommand.cs
+++ b/src/Hst.Imager.Core/Commands/FsCommands/FsMkLinkCommand.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hst.Amiga.FileSystems;
+using Hst.Core;
+using Hst.Imager.Core.Helpers;
+using Hst.Imager.Core.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Hst.Imager.Core.Commands.FsCommands;
+
+public class FsMkLinkCommand(ILogger<FsMkLinkCommand> logger, ICommandHelper commandHelper,
+    IEnumerable<IPhysicalDrive> physicalDrives, string fromPath, string toPath)
+    : FsCommandBase(commandHelper, physicalDrives)
+{
+    public override async Task<Result> Execute(CancellationToken token)
+    {
+        OnInformationMessage($"Creating link from path '{fromPath}' to path '{toPath}'");
+        
+        OnDebugMessage($"Opening '{fromPath}' as readable");
+        
+        var fromPathResult = commandHelper.ResolveMedia(fromPath, true);
+        if (fromPathResult.IsFaulted)
+        {
+            return new Result(fromPathResult.Error);
+        }
+
+        OnDebugMessage($"Media Path: '{fromPathResult.Value.MediaPath}'");
+        OnDebugMessage($"File System Path: '{fromPathResult.Value.FileSystemPath}'");
+
+        if (await IsAdfMedia(fromPathResult.Value))
+        {
+            return await CreateAdfMediaLink(fromPathResult.Value);
+        }
+
+        return await CreateDiskMediaLink(fromPathResult.Value);
+    }
+    
+    private async Task<Result> CreateAdfMediaLink(MediaResult resolvedMedia)
+    {
+        var mediaResult = await commandHelper.GetWritableFileMedia(resolvedMedia.MediaPath);
+        if (mediaResult.IsFaulted)
+        {
+            return new Result<IEntryIterator>(mediaResult.Error);
+        }
+        
+        using var media = mediaResult.Value;
+        
+        var fileSystemVolumeResult = await MountAdfFileSystemVolume(media.Stream);
+        if (fileSystemVolumeResult.IsFaulted)
+        {
+            return new Result<IEntryIterator>(fileSystemVolumeResult.Error);
+        }
+
+        var fileSystemVolume = fileSystemVolumeResult.Value;
+        var fromPathComponents = resolvedMedia.FileSystemPath.Split(resolvedMedia.DirectorySeparatorChar);
+
+        await CreateLink(fileSystemVolume, fromPathComponents);
+        
+        return  new Result();
+    }
+
+    private async Task<Result> CreateDiskMediaLink(MediaResult resolvedMedia)
+    {
+        var readableMediaResult = await commandHelper.GetWritableMedia(physicalDrives, resolvedMedia.MediaPath);
+        if (readableMediaResult.IsFaulted)
+        {
+            return new Result(readableMediaResult.Error);
+        }
+
+        var fileSystemPath = resolvedMedia.FileSystemPath ?? string.Empty;
+        var directorySeparatorChar = resolvedMedia.DirectorySeparatorChar;
+
+        var piStormRdbMediaResult = MediaHelper.GetPiStormRdbMedia(
+            readableMediaResult.Value, fileSystemPath, directorySeparatorChar);
+
+        using var media = piStormRdbMediaResult.Media;
+        fileSystemPath = piStormRdbMediaResult.FileSystemPath;
+
+        var parts = fileSystemPath.Split(directorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+
+        if (parts.Length < 1 || !(parts[0].Equals("mbr", StringComparison.OrdinalIgnoreCase) || 
+                                      parts[0].Equals("gpt", StringComparison.OrdinalIgnoreCase) || 
+                                      parts[0].Equals("rdb", StringComparison.OrdinalIgnoreCase)))
+        {
+            return new Result(new Error($"From path '{fromPath}' does not contain partition table (mbr, gpt, rdb)"));
+        }
+
+        if (parts.Length < 2)
+        {
+            return new Result(new Error($"From path '{fromPath}' does not contain partition number or partition name"));
+        }
+
+        switch (parts[0].ToLowerInvariant())
+        {
+            case "mbr":
+                return new Result(new Error($"Creating link on MBR partition is not supported"));
+            case "gpt":
+                return new Result(new Error($"Creating link on GPT partition is not supported"));
+            case "rdb":
+                return await CreateRdbLink(media, parts.Skip(1).ToArray());
+            default:
+                return new Result(new Error($"Unsupported media path '{fromPath}'"));
+        }
+    }
+    
+    private async Task<Result> CreateRdbLink(Media media, string[] fromParts)
+    {
+        var partitionPart = fromParts[0];
+        var fileSystemResult = await MountRdbFileSystemVolume(media, partitionPart);
+        if (fileSystemResult.IsFaulted)
+        {
+            return new Result(fileSystemResult.Error);
+        }
+        
+        await using var fileSystem = fileSystemResult.Value.Item2;
+        
+        // first from part contains partition number, therefore its skipped
+        await CreateLink(fileSystem, fromParts.Skip(1).ToArray());
+
+        return new Result();
+    }
+    
+    private async Task CreateLink(IFileSystemVolume fileSystemVolume, string[] fromPartComponents)
+    {
+        for (var i = 0; i < fromPartComponents.Length; i++)
+        {
+            var pathComponent = fromPartComponents[i];
+
+            if (i < fromPartComponents.Length - 1)
+            {
+                await fileSystemVolume.ChangeDirectory(pathComponent);
+                continue;                
+            }
+
+            await fileSystemVolume.CreateLink(pathComponent, toPath);
+        }
+    }
+}

--- a/src/Hst.Imager.Core/Commands/FsCopyCommand.cs
+++ b/src/Hst.Imager.Core/Commands/FsCopyCommand.cs
@@ -105,6 +105,7 @@ public class FsCopyCommand(
                     switch (entry.Type)
                     {
                         case EntryType.Dir:
+                        case EntryType.LinkDir:
                             dirsCount++;
                             var createDirectoryResult = await destEntryWriter.CreateDirectory(entry,
                                 entry.RelativePathComponents, skipAttributes, isSingleFileOrUsesPattern);
@@ -114,6 +115,7 @@ public class FsCopyCommand(
                             }
                             break;
                         case EntryType.File:
+                        case EntryType.LinkFile:
                         {
                             filesCount++;
                             totalBytes += entry.Size;

--- a/src/Hst.Imager.Core/Commands/FsExtractCommand.cs
+++ b/src/Hst.Imager.Core/Commands/FsExtractCommand.cs
@@ -102,6 +102,7 @@ public class FsExtractCommand(
                     switch (entry.Type)
                     {
                         case EntryType.Dir:
+                        case EntryType.LinkDir:
                             dirsCount++;
                             var createDirectoryResult = await destEntryWriter.CreateDirectory(entry, entry.RelativePathComponents, skipAttributes,
                                 isSingleFileOrUsesPattern);
@@ -111,6 +112,7 @@ public class FsExtractCommand(
                             }
                             break;
                         case EntryType.File:
+                        case EntryType.LinkFile:
                         {
                             filesCount++;
                             totalBytes += entry.Size;

--- a/src/Hst.Imager.Core/Commands/PathExistsError.cs
+++ b/src/Hst.Imager.Core/Commands/PathExistsError.cs
@@ -1,0 +1,5 @@
+﻿using Hst.Core;
+
+namespace Hst.Imager.Core.Commands;
+
+public class PathExistsError(string message) : Error(message);

--- a/src/Hst.Imager.Core/Constants.cs
+++ b/src/Hst.Imager.Core/Constants.cs
@@ -17,6 +17,7 @@ namespace Hst.Imager.Core
         public static class EntryPropertyNames
         {
             public const string Comment = "Comment";
+            public const string Link = "Link";
             public const string ProtectionBits = "$ProtectionBits";
         }
     }

--- a/src/Hst.Imager.Core/Hst.Imager.Core.csproj
+++ b/src/Hst.Imager.Core/Hst.Imager.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-      <PackageReference Include="Hst.Amiga" Version="0.5.215" />
+      <PackageReference Include="Hst.Amiga" Version="0.6.221" />
       <PackageReference Include="hst.compression" Version="0.4.85" />
       <PackageReference Include="Hst.Core" Version="0.4.85" />
       <PackageReference Include="LTRData.DiscUtils.Containers" Version="1.0.74" />

--- a/src/Hst.Imager.Core/Models/FileSystems/EntryType.cs
+++ b/src/Hst.Imager.Core/Models/FileSystems/EntryType.cs
@@ -3,5 +3,7 @@
 public enum EntryType
 {
     Dir,
-    File
+    File,
+    LinkDir,
+    LinkFile
 }

--- a/src/Hst.Imager.Core/PathComponents/BackslashMediaPath.cs
+++ b/src/Hst.Imager.Core/PathComponents/BackslashMediaPath.cs
@@ -1,15 +1,22 @@
 ﻿using System;
+using System.Linq;
 
 namespace Hst.Imager.Core.PathComponents
 {
+    /// <summary>
+    /// Backslash media path that splits and joins paths using backslash as separator.
+    /// </summary>
     public class BackslashMediaPath : IMediaPath
     {
         public char PathSeparator => '\\';
 
         public string[] Split(string path) =>
-            path.Split(new[] { PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+            (path.StartsWith(PathSeparator) ? new []{PathSeparator.ToString()} : Array.Empty<string>())
+            .Concat(path.Split(PathSeparator, StringSplitOptions.RemoveEmptyEntries)).ToArray();
 
         public string Join(string[] pathComponents) =>
-            string.Join(PathSeparator.ToString(), pathComponents);
+            pathComponents.Length > 0 && pathComponents[0] == PathSeparator.ToString()
+                ? string.Concat(PathSeparator, string.Join(PathSeparator.ToString(), pathComponents.Skip(1)))
+                : string.Join(PathSeparator.ToString(), pathComponents);
     }
 }

--- a/src/Hst.Imager.Core/PathComponents/EntryIteratorFunctions.cs
+++ b/src/Hst.Imager.Core/PathComponents/EntryIteratorFunctions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System;
+using Hst.Amiga.FileSystems;
 
 namespace Hst.Imager.Core.PathComponents;
 
@@ -209,7 +210,7 @@ public static class EntryIteratorFunctions
         bool recursive,
         string entryPath,
         string rawPath,
-        bool isDir,
+        EntryType entryType,
         DateTime date,
         long size,
         string attributes,
@@ -232,11 +233,19 @@ public static class EntryIteratorFunctions
             RelativePathComponents = relativePathComponents.ToArray(),
             Date = date,
             Size = size,
-            Type = isDir
-                ? Models.FileSystems.EntryType.Dir
-                : Models.FileSystems.EntryType.File,
+            Type = GetType(entryType),
             Attributes = attributes,
             Properties = properties
         };
     }
+
+    private static Models.FileSystems.EntryType GetType(EntryType entryType) =>
+        entryType switch
+        {
+            EntryType.Dir => Models.FileSystems.EntryType.Dir,
+            EntryType.DirLink => Models.FileSystems.EntryType.LinkDir,
+            EntryType.File => Models.FileSystems.EntryType.File,
+            EntryType.FileLink => Models.FileSystems.EntryType.LinkFile,
+            _ => throw new ArgumentOutOfRangeException(nameof(entryType), entryType, $"Entry type '{entryType}' is out of range")
+        };
 }

--- a/src/Hst.Imager.Core/PathComponents/ForwardSlashMediaPath.cs
+++ b/src/Hst.Imager.Core/PathComponents/ForwardSlashMediaPath.cs
@@ -1,15 +1,22 @@
 ﻿using System;
+using System.Linq;
 
 namespace Hst.Imager.Core.PathComponents
 {
+    /// <summary>
+    /// Forward slash media path that splits and joins paths using backslash as separator.
+    /// </summary>
     public class ForwardSlashMediaPath : IMediaPath
     {
         public char PathSeparator => '/';
 
         public string[] Split(string path) =>
-            path.Split(new[] { PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+            (path.StartsWith(PathSeparator) ? new []{PathSeparator.ToString()} : Array.Empty<string>())
+            .Concat(path.Split(PathSeparator, StringSplitOptions.RemoveEmptyEntries)).ToArray();
 
         public string Join(string[] pathComponents) =>
-            string.Join(PathSeparator.ToString(), pathComponents);
+            pathComponents.Length > 0 && pathComponents[0] == PathSeparator.ToString()
+                ? string.Concat(PathSeparator, string.Join(PathSeparator.ToString(), pathComponents.Skip(1)))
+                : string.Join(PathSeparator.ToString(), pathComponents);
     }
 }


### PR DESCRIPTION
This PR adds a `fs mklink` command that creates hard links in FastFileSystem and PFS3 file systems.