### PR TITLE
Fix pfs3 overwrite file hang, delete cache layer files, flush cache progressbar and detect .vhd using magic bytes

### DIFF
--- a/src/Hst.Imager.Core.Tests/CommandTests/GivenFsCopyCommandCopyingSingleFileFromAndToSameLocalDirectory.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/GivenFsCopyCommandCopyingSingleFileFromAndToSameLocalDirectory.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Hst.Imager.Core.Commands;
+using Hst.Imager.Core.MagicBytes;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -176,8 +177,8 @@ public class GivenFsCopyCommandCopyingSingleFileFromAndToSameLocalDirectory : Fs
 
             // arrange - create existing file2 copy as adf
             var adfBytes = new byte[Amiga.FloppyDiskConstants.DoubleDensity.Size];
-            Array.Copy(MagicBytes.AdfDosMagicNumber, 0, adfBytes, 0,
-                MagicBytes.AdfDosMagicNumber.Length);
+            Array.Copy(KnownMagicBytes.AdfDosMagicBytes, 0, adfBytes, 0,
+                KnownMagicBytes.AdfDosMagicBytes.Length);
             await File.WriteAllBytesAsync(Path.Combine(mediaPath, "file2_copy.txt"), adfBytes);
             
             // arrange - create fs copy command
@@ -220,8 +221,8 @@ public class GivenFsCopyCommandCopyingSingleFileFromAndToSameLocalDirectory : Fs
 
             // arrange - create existing file2 copy as adf
             var adfBytes = new byte[Amiga.FloppyDiskConstants.DoubleDensity.Size];
-            Array.Copy(MagicBytes.AdfDosMagicNumber, 0, adfBytes, 0,
-                MagicBytes.AdfDosMagicNumber.Length);
+            Array.Copy(KnownMagicBytes.AdfDosMagicBytes, 0, adfBytes, 0,
+                KnownMagicBytes.AdfDosMagicBytes.Length);
             await File.WriteAllBytesAsync(Path.Combine(mediaPath, "file2_copy.txt"), adfBytes);
             
             // arrange - create fs copy command
@@ -279,8 +280,8 @@ public class GivenFsCopyCommandCopyingSingleFileFromAndToSameLocalDirectory : Fs
 
             // arrange - create existing file2 copy as mbr img
             var mbrBytes = new byte[512];
-            Array.Copy(MagicBytes.MbrMagicNumber, 0, mbrBytes, 0x1fe,
-                MagicBytes.MbrMagicNumber.Length);
+            Array.Copy(KnownMagicBytes.MbrMagicNumbers, 0, mbrBytes, 0x1fe,
+                KnownMagicBytes.MbrMagicNumbers.Length);
             await File.WriteAllBytesAsync(Path.Combine(mediaPath, "file2_copy.txt"), mbrBytes);
             
             // arrange - create fs copy command
@@ -323,8 +324,8 @@ public class GivenFsCopyCommandCopyingSingleFileFromAndToSameLocalDirectory : Fs
 
             // arrange - create existing file2 copy as mbr img
             var mbrBytes = new byte[512];
-            Array.Copy(MagicBytes.MbrMagicNumber, 0, mbrBytes, 0x1fe,
-                MagicBytes.MbrMagicNumber.Length);
+            Array.Copy(KnownMagicBytes.MbrMagicNumbers, 0, mbrBytes, 0x1fe,
+                KnownMagicBytes.MbrMagicNumbers.Length);
             await File.WriteAllBytesAsync(Path.Combine(mediaPath, "file2_copy.txt"), mbrBytes);
             
             // arrange - create fs copy command

--- a/src/Hst.Imager.Core.Tests/CommandTests/GivenFsCopyCommandWithMbrFatFormattedDisk.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/GivenFsCopyCommandWithMbrFatFormattedDisk.cs
@@ -251,17 +251,6 @@ public class GivenFsCopyCommandWithMbrFatFormattedDisk : FsCommandTestBase
             Assert.Equal(string.Empty, result.Error?.ToString() ?? string.Empty);
             Assert.True(result.IsSuccess);
 
-
-            var fsDirCommand = new FsDirCommand(new NullLogger<FsDirCommand>(), testCommandHelper,
-                new List<IPhysicalDrive>(), Path.Combine(destPath, "mbr", "1", "dir1", "dir2"), true);
-            var entries = new List<Models.FileSystems.Entry>();
-            fsDirCommand.EntriesRead += (sender, args) =>
-            {
-                entries = args.EntriesInfo.Entries.ToList();
-            };
-            var r2 = await fsDirCommand.Execute(cancellationTokenSource.Token);
-            Assert.True(r2.IsSuccess);
-
             // arrange - get fat file system
             var mediaResult = await testCommandHelper.GetReadableMedia(
                 Enumerable.Empty<IPhysicalDrive>(), destPath);

--- a/src/Hst.Imager.Core.Tests/GivenReadCommand.cs
+++ b/src/Hst.Imager.Core.Tests/GivenReadCommand.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using Hst.Core.Extensions;
+using Hst.Imager.Core.MagicBytes;
 
 namespace Hst.Imager.Core.Tests
 {
@@ -354,7 +355,7 @@ namespace Hst.Imager.Core.Tests
 
                 // assert - data written is identical to uncompressed source bytes
                 var destinationBytes = await File.ReadAllBytesAsync(destinationPath);
-                Assert.True(HasZipMagicNumber(destinationBytes));
+                Assert.True(MagicBytesRegister.Instance.TryResolve(destinationBytes, out var dataType) && dataType == DataType.Zip);
                 Assert.True(data.Length > destinationBytes.Length);
 
                 var uncompressedDestData = await UncompressZipData(destinationBytes);
@@ -395,7 +396,7 @@ namespace Hst.Imager.Core.Tests
 
                 // assert - data written is identical to uncompressed source bytes
                 var destinationBytes = await File.ReadAllBytesAsync(destinationPath);
-                Assert.True(HasGZipMagicNumber(destinationBytes));
+                Assert.True(MagicBytesRegister.Instance.TryResolve(destinationBytes, out var dataType) && dataType == DataType.Gzip);
                 Assert.True(data.Length > destinationBytes.Length);
 
                 var uncompressedDestData = await UncompressGZipData(destinationBytes);
@@ -410,14 +411,6 @@ namespace Hst.Imager.Core.Tests
                 }
             }
         }
-
-        private static bool HasZipMagicNumber(byte[] data) =>
-            MagicBytes.HasMagicNumber(MagicBytes.ZipMagicNumber1, data, 0) ||
-            MagicBytes.HasMagicNumber(MagicBytes.ZipMagicNumber2, data, 0) ||
-            MagicBytes.HasMagicNumber(MagicBytes.ZipMagicNumber3, data, 0);
-
-        private static bool HasGZipMagicNumber(byte[] data) =>
-            MagicBytes.HasMagicNumber(MagicBytes.GzHeader, data, 0);
 
         private static async Task<byte[]> UncompressZipData(byte[] data)
         {

--- a/src/Hst.Imager.Core.Tests/Hst.Imager.Core.Tests.csproj
+++ b/src/Hst.Imager.Core.Tests/Hst.Imager.Core.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Hst.Core" Version="0.4.85" />
+        <PackageReference Include="Hst.Core" Version="0.4.87" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="xunit" Version="2.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/src/Hst.Imager.Core.Tests/TestCommandHelper.cs
+++ b/src/Hst.Imager.Core.Tests/TestCommandHelper.cs
@@ -1,4 +1,6 @@
-﻿using Hst.Imager.Core.Helpers;
+﻿using DiscUtils;
+using Hst.Imager.Core.Helpers;
+using Hst.Imager.Core.MagicBytes;
 
 namespace Hst.Imager.Core.Tests
 {
@@ -28,6 +30,56 @@ namespace Hst.Imager.Core.Tests
         {
             this.RigidDiskBlock = rigidDiskBlock;
             this.TestMedias = new List<TestMedia>();
+        }
+
+        public override async Task<DataType> DetectDataType(string path)
+        {
+            var testMedia = TestMedias.FirstOrDefault(x => x.Path.Equals(path, StringComparison.OrdinalIgnoreCase));
+
+            if (testMedia == null)
+            {
+                return await base.DetectDataType(path);
+            }
+            
+            testMedia.Stream.Seek(0, SeekOrigin.Begin);
+            var data = new byte[65536];
+            if (await testMedia.Stream.ReadAsync(data) == 0)
+            {
+                return DataType.Unknown;
+            }
+        
+            MagicBytesRegister.Instance.TryResolve(data, out var dataType);
+
+            return dataType;
+        }
+
+        public override bool IsVhdValid(string path)
+        {
+            var testMedia = TestMedias.FirstOrDefault(x => x.Path.Equals(path, StringComparison.OrdinalIgnoreCase));
+
+            if (testMedia == null)
+            {
+                return base.IsVhdValid(path);
+            }
+
+            if (testMedia.Stream.Length == 0)
+            {
+                return false;
+            }
+            
+            VirtualDisk disk;
+            
+            try
+            {
+                disk = new DiscUtils.Vhd.Disk(testMedia.Stream, Ownership.None);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            disk.Dispose();
+            return true;
         }
 
         public async Task<byte[]> ReadMediaData(string path)

--- a/src/Hst.Imager.Core/Commands/AmigaFileSystemHelper.cs
+++ b/src/Hst.Imager.Core/Commands/AmigaFileSystemHelper.cs
@@ -11,6 +11,7 @@ using System.Text;
 using DiscUtils.Partitions;
 using DiscUtils.Streams;
 using Hst.Compression.Lha;
+using Hst.Imager.Core.MagicBytes;
 using Hst.Imager.Core.Models;
 
 namespace Hst.Imager.Core.Commands
@@ -64,43 +65,26 @@ namespace Hst.Imager.Core.Commands
                 : mediaStream.Length));
 
             mediaStream.Position = 0;
-            
-            // return file, if media has hunk magic number
-            if (MagicBytes.HasMagicNumber(MagicBytes.HunkMagicNumber, firstBytes, 0))
+
+            if (!MagicBytesRegister.Instance.TryResolve(firstBytes, out var dataType))
             {
-                return await GetMediaAsFileSystem(mediaStream, Path.GetFileName(mediaPath));
-            }
-            
-            // read file systems from adf, if media has adf magic number
-            if (MagicBytes.HasMagicNumber(MagicBytes.AdfDosMagicNumber, firstBytes, 0))
-            {
-                return await FindFileSystemsInAdf(media, mediaStream, fileSystemName);
+                return new Result<IEnumerable<Tuple<string, byte[]>>>(new List<Tuple<string, byte[]>>());
             }
 
-            // read file systems from lha, if media has lha magic number
-            if (MagicBytes.HasMagicNumber(MagicBytes.LhaMagicNumber, firstBytes, 2))
+            switch (dataType)
             {
-                return await FindFileSystemsInLha(mediaStream, fileSystemName);
-            }
-
-            // read file systems from iso and adf files in iso, if media has iso magic number
-            if (MagicBytes.HasMagicNumber(MagicBytes.Iso9660MagicNumber, firstBytes, 0x8001) ||
-                MagicBytes.HasMagicNumber(MagicBytes.Iso9660MagicNumber, firstBytes, 0x8801) ||
-                MagicBytes.HasMagicNumber(MagicBytes.Iso9660MagicNumber, firstBytes, 0x9001))
-            {
-                return await FindFileSystemsInIso(media, mediaStream, fileSystemName);
-            }
-
-            // read file systems from rigid disk block, if media has rdb magic number
-            if (MagicBytes.HasMagicNumber(MagicBytes.RdbMagicNumber, firstBytes, 0))
-            {
-                return await FindFileSystemsInRdb(mediaStream, fileSystemName);
-            }
-
-            // read file systems from mbr pistorm rdb partitions, if media has mbr magic number
-            if (MagicBytes.HasMagicNumber(MagicBytes.MbrMagicNumber, firstBytes, 0x1fe))
-            {
-                return await FindFileSystemsInMbrPiStormRdb(mediaStream, fileSystemName);
+                case DataType.Hunk:
+                    return await GetMediaAsFileSystem(mediaStream, Path.GetFileName(mediaPath));
+                case DataType.Adf:
+                    return await FindFileSystemsInAdf(media, mediaStream, fileSystemName);
+                case DataType.Lha:
+                    return await FindFileSystemsInLha(mediaStream, fileSystemName);
+                case DataType.Iso9660:
+                    return await FindFileSystemsInIso(media, mediaStream, fileSystemName);
+                case DataType.Rdb:
+                    return await FindFileSystemsInRdb(mediaStream, fileSystemName);
+                case DataType.Mbr:
+                    return await FindFileSystemsInMbrPiStormRdb(mediaStream, fileSystemName);
             }
 
             return new Result<IEnumerable<Tuple<string, byte[]>>>(new List<Tuple<string, byte[]>>());

--- a/src/Hst.Imager.Core/Commands/BlankCommand.cs
+++ b/src/Hst.Imager.Core/Commands/BlankCommand.cs
@@ -56,7 +56,7 @@
             using var media = mediaResult.Value;
             var stream = media.Stream;
 
-            if (!commandHelper.IsVhd(path))
+            if (media.Type != Media.MediaType.Vhd)
             {
                 stream.SetLength(mediaSize);
             }

--- a/src/Hst.Imager.Core/Commands/CommandHelper.cs
+++ b/src/Hst.Imager.Core/Commands/CommandHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO.Compression;
 using Hst.Imager.Core.Apis;
 using Hst.Imager.Core.Extensions;
+using Hst.Imager.Core.MagicBytes;
 using Hst.Imager.Core.PartitionTables;
 using Hst.Imager.Core.SparseFiles;
 using SharpCompress.Archives.Rar;
@@ -31,8 +32,9 @@ namespace Hst.Imager.Core.Commands
         private readonly bool createSparseFiles;
         private readonly bool useCache;
         private readonly CacheType cacheType;
+        private readonly int blockSize = 1024 * 1024;
         private readonly IList<IPhysicalDrive> activePhysicalDrives;
-        
+
         public event EventHandler<string> DebugMessage;
         public event EventHandler<string> WarningMessage;
         public event EventHandler<string> InformationMessage;
@@ -87,6 +89,54 @@ namespace Hst.Imager.Core.Commands
         {
         }
 
+        public virtual async Task<DataType> DetectDataType(string path)
+        {
+            if (!File.Exists(path))
+            {
+                return DataType.Unknown;
+            }
+            
+            await using var stream = File.OpenRead(path);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var data = new byte[65536];
+            if (await stream.ReadAsync(data) == 0)
+            {
+                return DataType.Unknown;
+            }
+        
+            MagicBytesRegister.Instance.TryResolve(data, out var dataType);
+
+            return dataType;
+        }
+        
+        public virtual bool IsVhdValid(string path)
+        {
+            var fileInfo = new FileInfo(path);
+            if (fileInfo.Length == 0)
+            {
+                return false;
+            }
+            
+            Stream stream = null;
+            VirtualDisk disk;
+            
+            try
+            {
+                stream = File.OpenRead(path);
+                disk = new DiscUtils.Vhd.Disk(stream, Ownership.Dispose);
+            }
+            catch (Exception)
+            {
+                stream?.Close();
+                stream?.Dispose();
+                return false;
+            }
+
+            disk.Dispose();
+            return true;
+        }
+        
         /// <summary>
         /// Clear active medias to avoid source and destination being reused between commands
         /// </summary>
@@ -343,9 +393,11 @@ namespace Hst.Imager.Core.Commands
                 return new Result<Media>(activeMedia);
             }
 
+            var isVhd = await DetectDataType(path) == DataType.Vhd;
+            
             var name = Path.GetFileName(path);
 
-            if (!IsVhd(path))
+            if (!isVhd)
             {
                 var fileStream = File.Open(path, FileMode.Open, FileAccess.Read);
                 var fileMedia = await GetFileMedia(path, name, fileStream, byteSwap);
@@ -357,7 +409,7 @@ namespace Hst.Imager.Core.Commands
             
             try
             {
-                vhdMedia = GetVhdMedia(path, name, false, byteSwap, useCache, cacheType);
+                vhdMedia = GetVhdMedia(path, name, false, byteSwap);
             }
             catch (Exception e)
             {
@@ -382,9 +434,10 @@ namespace Hst.Imager.Core.Commands
             var headerBytes = new byte[512];
             var bytesRead = await stream.ReadAsync(headerBytes, 0, headerBytes.Length);
 
+            MagicBytesRegister.Instance.TryResolve(headerBytes, out var dataType);
+
             // rar media
-            var rarMedia = headerBytes.HasMagicNumber(MagicBytes.RarMagicNumber150) ||
-                           headerBytes.HasMagicNumber(MagicBytes.RarMagicNumber500)
+            var rarMedia = dataType == DataType.Rar
                 ? await ResolveRarMedia(path, name, stream, byteSwap)
                 : null;
             if (rarMedia != null)
@@ -393,9 +446,7 @@ namespace Hst.Imager.Core.Commands
             }
 
             // zip media
-            var zipMedia = headerBytes.HasMagicNumber(MagicBytes.ZipMagicNumber1) ||
-                           headerBytes.HasMagicNumber(MagicBytes.ZipMagicNumber2) ||
-                           headerBytes.HasMagicNumber(MagicBytes.ZipMagicNumber3)
+            var zipMedia = dataType == DataType.Zip 
                 ? await ResolveZipMedia(path, name, stream, byteSwap)
                 : null;
             if (zipMedia != null)
@@ -403,17 +454,17 @@ namespace Hst.Imager.Core.Commands
                 return zipMedia;
             }
 
-            // zx media
-            var zxMedia = headerBytes.HasMagicNumber(MagicBytes.ZxHeader)
-                ? await ResolveZxMedia(path, name, stream, byteSwap)
+            // xz media
+            var xzMedia = dataType == DataType.Xz
+                ? await ResolveXzMedia(path, name, stream, byteSwap)
                 : null;
-            if (zxMedia != null)
+            if (xzMedia != null)
             {
-                return zxMedia;
+                return xzMedia;
             }
 
             // gzip stream
-            var gzMedia = headerBytes.HasMagicNumber(MagicBytes.GzHeader)
+            var gzMedia = dataType == DataType.Gzip
                 ? await ResolveGzMedia(path, name, stream, byteSwap)
                 : null;
             if (gzMedia != null)
@@ -421,6 +472,15 @@ namespace Hst.Imager.Core.Commands
                 return gzMedia;
             }
 
+            // vhd media
+            var vhdMedia = dataType == DataType.Vhd
+                ? GetVhdMedia(path, name, stream, false, byteSwap)
+                : null;
+            if (vhdMedia != null)
+            {
+                return vhdMedia;
+            }
+            
             // raw stream
             stream.Position = 0;
             var baseStream = byteSwap
@@ -429,10 +489,41 @@ namespace Hst.Imager.Core.Commands
             return new Media(path, name, Media.MediaType.Raw, false, baseStream, byteSwap);
         }
 
-        private Media GetVhdMedia(string path, string name, bool writeable, bool byteSwap, bool useCache,
-            CacheType cacheType = CacheType.Disk, int blockSize = 1024 * 1024)
+        private Media GetVhdMedia(string path, string name, Stream stream, bool writeable, bool byteSwap)
         {
-            var vhdDisk = VirtualDisk.OpenDisk(path, writeable ? FileAccess.ReadWrite : FileAccess.Read);
+            var vhdDisk = new Disk(stream, Ownership.Dispose);
+            
+            if (vhdDisk == null)
+            {
+                throw new InvalidOperationException($"Failed to open vhd disk '{path}'");
+            }
+            
+            vhdDisk.Content.Position = 0;
+            var baseStream = new SectorStream(vhdDisk.Content, byteSwap: byteSwap, leaveOpen: false);
+            var vhdStream = useCache
+                ? CacheHelper.AddLayeredCache(path, baseStream, writeable, blockSize, cacheType)
+                : baseStream;
+            
+            return new DiskMedia(path, name, Media.MediaType.Vhd, false, vhdDisk,
+                byteSwap, vhdStream);
+        }
+
+        private Media GetVhdMedia(string path, string name, bool writeable, bool byteSwap)
+        {
+            Stream fileStream = null;
+            Disk vhdDisk;
+            
+            try
+            {
+                fileStream = File.Open(path, FileMode.Open, writeable ? FileAccess.ReadWrite : FileAccess.Read);
+                vhdDisk = new Disk(fileStream, Ownership.Dispose);
+            }
+            catch (Exception e)
+            {
+                fileStream?.Close();
+                fileStream?.Dispose();
+                throw new InvalidOperationException($"Failed to open vhd disk '{path}': ", e);
+            }
             
             if (vhdDisk == null)
             {
@@ -477,10 +568,10 @@ namespace Hst.Imager.Core.Commands
             var baseStream = byteSwap
                 ? new SectorStream(rarEntryStream, leaveOpen: false, byteSwap: true)
                 : rarEntryStream;
+            var isVhd = MagicBytesRegister.Instance.TryResolve(headerBytes, out var dataType)
+                        && dataType == DataType.Vhd;
             return new Media(path, Path.GetFileName(rarEntry.Key),
-                MagicBytes.HasMagicNumber(MagicBytes.VhdMagicNumber, headerBytes, 0)
-                    ? Media.MediaType.CompressedVhd
-                    : Media.MediaType.CompressedRaw, false, new InterceptorStream(baseStream,
+                isVhd ? Media.MediaType.CompressedVhd : Media.MediaType.CompressedRaw, false, new InterceptorStream(baseStream,
                     length: rarEntry.Size, closeHandler: stream.Dispose, readHandler: (buffer, offset, count) => 
                         rarEntryStream.Fill(buffer, offset, count)), byteSwap);
         }
@@ -513,16 +604,17 @@ namespace Hst.Imager.Core.Commands
             var baseStream = byteSwap
                 ? new SectorStream(zipEntryStream, leaveOpen: false, byteSwap: true)
                 : zipEntryStream;
+            var isVhd = MagicBytesRegister.Instance.TryResolve(headerBytes, out var dataType)
+                        && dataType == DataType.Vhd;
             return new Media(path, Path.GetFileName(zipEntry.Name),
-                MagicBytes.HasMagicNumber(MagicBytes.VhdMagicNumber, headerBytes, 0)
-                    ? Media.MediaType.CompressedVhd
-                    : Media.MediaType.CompressedRaw, false, new InterceptorStream(
+                isVhd ? Media.MediaType.CompressedVhd : Media.MediaType.CompressedRaw,
+                false, new InterceptorStream(
                     baseStream, length: zipEntry.Length, closeHandler: stream.Dispose,
                     readHandler: (buffer, offset, count) =>
                         zipEntryStream.Fill(buffer, offset, count)), byteSwap);
         }
 
-        private static async Task<Media> ResolveZxMedia(string path, string name, Stream stream, bool byteSwap)
+        private static async Task<Media> ResolveXzMedia(string path, string name, Stream stream, bool byteSwap)
         {
             stream.Position = 0;
             var sizeAndHeader = await GetStreamLength(new SharpCompress.Compressors.Xz.XZStream(stream));
@@ -532,10 +624,11 @@ namespace Hst.Imager.Core.Commands
             Stream baseStream = byteSwap
                 ? new SectorStream(zxStream, leaveOpen: false, byteSwap: true)
                 : zxStream;
+            var isVhd = MagicBytesRegister.Instance.TryResolve(sizeAndHeader.Item2, out var dataType)
+                        && dataType == DataType.Vhd;
             return new Media(path, name,
-                MagicBytes.HasMagicNumber(MagicBytes.VhdMagicNumber, sizeAndHeader.Item2, 0)
-                    ? Media.MediaType.CompressedVhd
-                    : Media.MediaType.CompressedRaw, false, new InterceptorStream(
+                isVhd ? Media.MediaType.CompressedVhd : Media.MediaType.CompressedRaw,
+                false, new InterceptorStream(
                     baseStream, length: sizeAndHeader.Item1, 
                     closeHandler: stream.Dispose, readHandler: (buffer, offset, count) => 
                         zxStream.Fill(buffer, offset, count)), byteSwap);
@@ -552,10 +645,11 @@ namespace Hst.Imager.Core.Commands
             Stream baseStream = byteSwap
                 ? new SectorStream(gZipStream, leaveOpen: false, byteSwap: true)
                 : gZipStream;
+            var isVhd = MagicBytesRegister.Instance.TryResolve(sizeAndHeader.Item2, out var dataType)
+                        && dataType == DataType.Vhd;
             return new Media(path, name,
-                MagicBytes.HasMagicNumber(MagicBytes.VhdMagicNumber, sizeAndHeader.Item2, 0)
-                    ? Media.MediaType.CompressedVhd
-                    : Media.MediaType.CompressedRaw, false,
+                isVhd ? Media.MediaType.CompressedVhd : Media.MediaType.CompressedRaw,
+                false,
                 new InterceptorStream(
                     baseStream, length: sizeAndHeader.Item1, 
                     closeHandler: stream.Dispose, readHandler: (buffer, offset, count) => 
@@ -587,7 +681,7 @@ namespace Hst.Imager.Core.Commands
             return new Tuple<long, byte[]>(size, headerBytes);
         }
 
-        public virtual Task<Result<Media>> GetWritableFileMedia(string path, ModifierEnum? modifiers = null, long? size = null, bool create = false)
+        public virtual async Task<Result<Media>> GetWritableFileMedia(string path, ModifierEnum? modifiers = null, long? size = null, bool create = false)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
@@ -611,7 +705,7 @@ namespace Hst.Imager.Core.Commands
             var media = GetActiveMedia(path);
             if (media != null)
             {
-                return Task.FromResult(new Result<Media>(media));
+                return new Result<Media>(media);
             }
 
             var destDir = Path.GetDirectoryName(path);
@@ -621,16 +715,17 @@ namespace Hst.Imager.Core.Commands
                 Directory.CreateDirectory(destDir);
             }
 
+            var isVhd = MediaHelper.IsVhd(path);
             var name = Path.GetFileName(path);
 
             if (create)
             {
-                if (!IsVhd(path))
+                if (!isVhd)
                 {
                     var fileStream = CreateWriteableStream(path, true, size ?? 0);
                     var fileMedia = ResolveWritableFileMedia(path, name, size ?? 0, fileStream, byteSwap);
                     activeMedias.Add(fileMedia);
-                    return Task.FromResult(new Result<Media>(fileMedia));
+                    return new Result<Media>(fileMedia);
                 }
 
                 if (size == null || size.Value == 0)
@@ -644,11 +739,15 @@ namespace Hst.Imager.Core.Commands
 
             if (!File.Exists(path))
             {
-                return Task.FromResult(
-                    new Result<Media>(new PathNotFoundError($"Path '{path}' not found", nameof(path))));
+                return new Result<Media>(new PathNotFoundError($"Path '{path}' not found", nameof(path)));
             }
 
-            if (!IsVhd(path))
+            if (isVhd && !IsVhdValid(path))
+            {
+                return new Result<Media>(new Error($"VHD file '{path}' is not valid"));
+            }
+            
+            if (await DetectDataType(path) != DataType.Vhd)
             {
                 var fileStream = CreateWriteableStream(path, false, size ?? 0);
                 var baseStream = byteSwap
@@ -656,22 +755,22 @@ namespace Hst.Imager.Core.Commands
                     : fileStream;
                 var fileMedia = new Media(path, name, Media.MediaType.Raw, false, baseStream, byteSwap);
                 this.activeMedias.Add(fileMedia);
-                return Task.FromResult(new Result<Media>(fileMedia));
+                return new Result<Media>(fileMedia);
             }
 
             Media vhdMedia;
             
             try
             {
-                vhdMedia = GetVhdMedia(path, name, true, byteSwap, useCache, cacheType);
+                vhdMedia = GetVhdMedia(path, name, true, byteSwap);
             }
             catch (Exception e)
             {
-                return Task.FromResult(new Result<Media>(new Error($"Failed to open vhd media '{path}': {e}")));
+                return new Result<Media>(new Error($"Failed to open vhd media '{path}': {e}"));
             }
             
             activeMedias.Add(vhdMedia);
-            return Task.FromResult(new Result<Media>(vhdMedia));
+            return new Result<Media>(vhdMedia);
         }
 
         private Media ResolveWritableFileMedia(string path, string name, long size, Stream stream, bool byteSwap)
@@ -757,11 +856,6 @@ namespace Hst.Imager.Core.Commands
         public bool IsGZip(string path)
         {
             return path.EndsWith(".gz", StringComparison.OrdinalIgnoreCase);
-        }
-
-        public bool IsVhd(string path)
-        {
-            return path.EndsWith(".vhd", StringComparison.OrdinalIgnoreCase);
         }
 
         public virtual async Task<DiskInfo> ReadDiskInfo(Media media,

--- a/src/Hst.Imager.Core/Commands/CommandHelper.cs
+++ b/src/Hst.Imager.Core/Commands/CommandHelper.cs
@@ -95,9 +95,22 @@ namespace Hst.Imager.Core.Commands
             foreach (var activeMedia in this.activeMedias)
             {
                 activeMedia.Dispose();
+                
+                DeleteLayerPath(activeMedia.Path);
             }
 
             this.activeMedias.Clear();
+        }
+
+        private static void DeleteLayerPath(string path)
+        {
+            var layerPath = PathHelper.GetLayerPath(path);
+
+            // delete layer path, if file exists 
+            if (File.Exists(layerPath))
+            {
+                File.Delete(layerPath);
+            }
         }
 
         public void ClearActiveMedia(string path)
@@ -110,6 +123,9 @@ namespace Hst.Imager.Core.Commands
             }
 
             activeMedia.Dispose();
+
+            DeleteLayerPath(path);
+            
             activeMedias.Remove(activeMedia);
         }
         
@@ -1289,13 +1305,7 @@ namespace Hst.Imager.Core.Commands
             {
                 activePhysicalDrive.Dispose();
                 
-                var layerPath = PathHelper.GetLayerPath(activePhysicalDrive.Path);
-
-                // delete layer path, if file exists 
-                if (File.Exists(layerPath))
-                {
-                    File.Delete(layerPath);
-                }
+                DeleteLayerPath(activePhysicalDrive.Path);
             }
 
             activePhysicalDrives.Clear();

--- a/src/Hst.Imager.Core/Commands/FsCommandBase.cs
+++ b/src/Hst.Imager.Core/Commands/FsCommandBase.cs
@@ -1,7 +1,7 @@
 ﻿using DiscUtils.ExFat;
 using DiscUtils.Ntfs;
 using Hst.Imager.Core.Caching;
-using Hst.Imager.Core.Extensions;
+using Hst.Imager.Core.MagicBytes;
 using Hst.Imager.Core.UaeMetadatas;
 
 namespace Hst.Imager.Core.Commands;
@@ -57,12 +57,8 @@ public abstract partial class FsCommandBase : CommandBase
         stream.Seek(0, SeekOrigin.Begin);
         var sectorBytes = await stream.ReadBytes(512);
 
-        if (!MagicBytes.HasMagicNumber(MagicBytes.AdfDosMagicNumber, sectorBytes, 0))
-        {
-            return false;
-        }
-
-        return sectorBytes[3] <= 7;
+        return MagicBytesRegister.Instance.TryResolve(sectorBytes, out var dataType) &&
+               dataType == DataType.Adf;
     }
 
     private async Task<bool> IsZipMedia(MediaResult mediaResult)
@@ -78,8 +74,8 @@ public abstract partial class FsCommandBase : CommandBase
         stream.Seek(0, SeekOrigin.Begin);
         var sectorBytes = await stream.ReadBytes(512);
 
-        return MagicBytes.HasMagicNumber(MagicBytes.ZipMagicNumber1, sectorBytes, 0) || MagicBytes.HasMagicNumber(MagicBytes.ZipMagicNumber2, sectorBytes, 0) ||
-               MagicBytes.HasMagicNumber(MagicBytes.ZipMagicNumber3, sectorBytes, 0);
+        return MagicBytesRegister.Instance.TryResolve(sectorBytes, out var dataType) &&
+               dataType == DataType.Zip;
     }
     
     private async Task<bool> IsLhaMedia(MediaResult mediaResult)
@@ -95,7 +91,8 @@ public abstract partial class FsCommandBase : CommandBase
         stream.Seek(0, SeekOrigin.Begin);
         var sectorBytes = await stream.ReadBytes(512);
 
-        return MagicBytes.HasMagicNumber(MagicBytes.LhaMagicNumber, sectorBytes, 2);
+        return MagicBytesRegister.Instance.TryResolve(sectorBytes, out var dataType) &&
+               dataType == DataType.Lha;
     }
 
     private async Task<bool> IsLzxMedia(MediaResult mediaResult)
@@ -111,7 +108,8 @@ public abstract partial class FsCommandBase : CommandBase
         stream.Seek(0, SeekOrigin.Begin);
         var sectorBytes = await stream.ReadBytes(512);
 
-        return MagicBytes.HasMagicNumber(MagicBytes.LzxMagicNumber, sectorBytes, 0);
+        return MagicBytesRegister.Instance.TryResolve(sectorBytes, out var dataType) &&
+               dataType == DataType.Lzx;
     }
     
     private async Task<bool> IsLzwMedia(MediaResult mediaResult)
@@ -127,7 +125,8 @@ public abstract partial class FsCommandBase : CommandBase
         stream.Seek(0, SeekOrigin.Begin);
         var sectorBytes = await stream.ReadBytes(512);
 
-        return MagicBytes.HasMagicNumber(MagicBytes.LzwMagicNumber, sectorBytes, 0);
+        return MagicBytesRegister.Instance.TryResolve(sectorBytes, out var dataType) &&
+               dataType == DataType.Lzw;
     }
 
     private async Task<bool> IsIso9660Media(MediaResult mediaResult)
@@ -140,83 +139,11 @@ public abstract partial class FsCommandBase : CommandBase
 
         await using var stream = File.OpenRead(mediaResult.MediaPath);
 
-        // offset: 0x8000 / sector 64
-        stream.Seek(0x8000, SeekOrigin.Begin);
-        var sectorBytes = await stream.ReadBytes(512);
-
-        // return true, if offset 0x8001 has iso magic number
-        if (MagicBytes.HasMagicNumber(MagicBytes.Iso9660MagicNumber, sectorBytes, 1))
-        {
-            return true;
-        }
-
-        // offset: 0x8800 / sector 68
-        stream.Seek(0x8800, SeekOrigin.Begin);
-        sectorBytes = await stream.ReadBytes(512);
-
-        // return true, if offset 0x8801 has iso magic number
-        if (MagicBytes.HasMagicNumber(MagicBytes.Iso9660MagicNumber, sectorBytes, 1))
-        {
-            return true;
-        }
-
-        // offset: 0x9000 / sector 72
-        stream.Seek(0x9000, SeekOrigin.Begin);
-        sectorBytes = await stream.ReadBytes(512);
-
-        // return true, if offset 0x9001 has iso magic number
-        return MagicBytes.HasMagicNumber(MagicBytes.Iso9660MagicNumber, sectorBytes, 1);
-    }
-
-    protected async Task<bool> IsDiskMedia(MediaResult mediaResult)
-    {
-        // physical drive
-        if (Regexs.PhysicalDrivePathRegex.IsMatch(mediaResult.MediaPath) ||
-            Regexs.DevicePathRegex.IsMatch(mediaResult.MediaPath))
-        {
-            return true;
-        }
-
-        // return false, if media file doesnt exist
-        if (!File.Exists(mediaResult.MediaPath))
-        {
-            return false;
-        }
-
-        await using var stream = File.OpenRead(mediaResult.MediaPath);
-        return await HasDiskMediaMagicNumber(stream);
-    }
-
-    private async Task<bool> HasDiskMediaMagicNumber(Stream stream)
-    {
-        stream.Seek(0, SeekOrigin.Begin);
-        var sectorBytes = await stream.ReadBytes(MagicBytes.VhdMagicNumber.Length);
-
-        // virtual disk
-        if (MagicBytes.HasMagicNumber(MagicBytes.VhdMagicNumber, sectorBytes, 0))
-        {
-            return true;
-        }
-
-        // rigid disk block
-        for (var i = 1; i <= 16; i++)
-        {
-            if (MagicBytes.HasMagicNumber(MagicBytes.RdbMagicNumber, sectorBytes, 0))
-            {
-                return true;
-            }
-
-            // rigid disk block can only exist in sector 0-15
-            if (i == 16)
-            {
-                break;
-            }
-
-            stream.Seek(i * 512, SeekOrigin.Begin);
-            sectorBytes = await stream.ReadBytes(MagicBytes.VhdMagicNumber.Length);
-        }
-
-        return false;
+        var data = new byte[65536];
+        var bytesRead = await stream.ReadAsync(data, 0, data.Length);
+        return bytesRead > 0 &&
+               MagicBytesRegister.Instance.TryResolve(data, out var dataType) &&
+               dataType == DataType.Iso9660;
     }
 
     protected async Task<Result<IEntryIterator>> GetDirectoryEntryIterator(string path, bool recursive,
@@ -517,74 +444,6 @@ public abstract partial class FsCommandBase : CommandBase
             : new Result<IEntryWriter>(directoryEntryWriter);
     }
 
-    private async Task<Result<bool>> IsFileDiskMedia(string path, ModifierEnum modifiers)
-    {
-        var readableMediaResult = await commandHelper.GetReadableFileMedia(path, modifiers);
-        if (readableMediaResult.IsFaulted)
-        {
-            return new Result<bool>(readableMediaResult.Error);
-        }
-
-        using var media = readableMediaResult.Value;
-        var stream = media.Stream;
-
-        // read sector 0
-        var sectorBytes = new byte[512];
-        var bytesRead = await stream.ReadAsync(sectorBytes, 0, sectorBytes.Length);
-        if (bytesRead != sectorBytes.Length)
-        {
-            return new Result<bool>(false);
-        }
-
-        // return true, if media has adf size and has dos magic number
-        if (media.Size == Amiga.FloppyDiskConstants.DoubleDensity.Size &&
-            sectorBytes.HasMagicNumber(MagicBytes.AdfDosMagicNumber))
-        {
-            return new Result<bool>(true);
-        }
-        
-        // return true, if sector 0 has mbr, rdb or vhd magic number
-        if (sectorBytes.HasMagicNumber(MagicBytes.MbrMagicNumber, 0x1fe) ||
-            sectorBytes.HasMagicNumber(MagicBytes.RdbMagicNumber) ||
-            sectorBytes.HasMagicNumber(MagicBytes.VhdMagicNumber))
-        {
-            return new Result<bool>(true);
-        }
-
-        // read sector 1
-        bytesRead = await stream.ReadAsync(sectorBytes, 0, sectorBytes.Length);
-        if (bytesRead != sectorBytes.Length)
-        {
-            return new Result<bool>(false);
-        }
-
-        // return true, if sector 1 has gpr or rdb magic number
-        if (sectorBytes.HasMagicNumber(MagicBytes.GptMagicNumber) ||
-            sectorBytes.HasMagicNumber(MagicBytes.RdbMagicNumber))
-        {
-            return new Result<bool>(true);
-        }
-
-        // read sector 2-15
-        for (var i = 2; i <= 15; i++)
-        {
-            // read sector
-            bytesRead = await stream.ReadAsync(sectorBytes, 0, sectorBytes.Length);
-            if (bytesRead != sectorBytes.Length)
-            {
-                return new Result<bool>(false);
-            }
-            
-            // return true, if sector 1 has rdb magic number
-            if (sectorBytes.HasMagicNumber(MagicBytes.RdbMagicNumber))
-            {
-                return new Result<bool>(true);
-            }
-        }
-        
-        return new Result<bool>(false);
-    }
-    
     protected async Task<Result<IEntryWriter>> GetEntryWriter(string destPath, bool recursive, bool createDestDirectory,
         bool forceOverwrite)
     {

--- a/src/Hst.Imager.Core/Commands/FsCommands/FsMkDirCommand.cs
+++ b/src/Hst.Imager.Core/Commands/FsCommands/FsMkDirCommand.cs
@@ -4,9 +4,9 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using DiscUtils.Streams;
 using Hst.Core;
 using Hst.Imager.Core.Helpers;
+using Hst.Imager.Core.MagicBytes;
 using Hst.Imager.Core.Models;
 using Hst.Imager.Core.Models.FileSystems;
 using Hst.Imager.Core.PathComponents;
@@ -37,8 +37,8 @@ public class FsMkDirCommand(ILogger<FsMkDirCommand> logger, ICommandHelper comma
         {
             return CreateLocalDirectory(path);
         }
-        
-        if (await IsAdfMedia(pathResult.Value))
+
+        if (await commandHelper.DetectDataType(pathResult.Value.MediaPath) == DataType.Adf)
         {
             return await CreateAdfMediaDirectory(pathResult.Value, false);
         }

--- a/src/Hst.Imager.Core/Commands/FsCommands/FsMkLinkCommand.cs
+++ b/src/Hst.Imager.Core/Commands/FsCommands/FsMkLinkCommand.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Hst.Amiga.FileSystems;
 using Hst.Core;
 using Hst.Imager.Core.Helpers;
+using Hst.Imager.Core.MagicBytes;
 using Hst.Imager.Core.Models;
 using Microsoft.Extensions.Logging;
 
@@ -30,7 +31,7 @@ public class FsMkLinkCommand(ILogger<FsMkLinkCommand> logger, ICommandHelper com
         OnDebugMessage($"Media Path: '{fromPathResult.Value.MediaPath}'");
         OnDebugMessage($"File System Path: '{fromPathResult.Value.FileSystemPath}'");
 
-        if (await IsAdfMedia(fromPathResult.Value))
+        if (await commandHelper.DetectDataType(fromPathResult.Value.MediaPath) == DataType.Adf)
         {
             return await CreateAdfMediaLink(fromPathResult.Value);
         }

--- a/src/Hst.Imager.Core/Commands/FsDirCommand.cs
+++ b/src/Hst.Imager.Core/Commands/FsDirCommand.cs
@@ -1,5 +1,6 @@
 ﻿using DiscUtils;
 using Hst.Imager.Core.Caching;
+using Hst.Imager.Core.MagicBytes;
 using Hst.Imager.Core.UaeMetadatas;
 
 namespace Hst.Imager.Core.Commands;
@@ -85,76 +86,40 @@ public class FsDirCommand(
         OnDebugMessage($"Media Path: '{pathResult.Value.MediaPath}'");
         OnDebugMessage($"File System Path: '{pathResult.Value.FileSystemPath}'");
 
-        // zip
-        var zipEntryIteratorResult = await GetZipEntryIterator(pathResult.Value, recursive);
-        if (zipEntryIteratorResult is { IsSuccess: true })
+        var dataType = await commandHelper.DetectDataType(pathResult.Value.MediaPath);
+
+        Result<IEntryIterator> entryIteratorResult = null;
+        switch (dataType)
         {
-            using var zipEntryIterator = zipEntryIteratorResult.Value;
-            var initializeResult = await zipEntryIterator.Initialize();
-            if (initializeResult.IsFaulted)
-            {
-                return new Result<IEntryIterator>(initializeResult.Error);
-            }
-            await ListEntries(zipEntryIterator);
-            return new Result();
+            case DataType.Zip:
+                entryIteratorResult = await GetZipEntryIterator(pathResult.Value, recursive);
+                break;
+            case DataType.Lha:
+                entryIteratorResult = await GetLhaEntryIterator(pathResult.Value, recursive);
+                break;
+            case DataType.Lzx:
+                entryIteratorResult = await GetLzxEntryIterator(pathResult.Value, recursive);
+                break;
+            case DataType.Adf:
+                entryIteratorResult = await GetAdfEntryIterator(pathResult.Value, recursive);
+                break;
+            case DataType.Iso9660:
+                entryIteratorResult = await GetIso9660EntryIterator(pathResult.Value, recursive);
+                break;
         }
-        
-        // lha
-        var lhaEntryIteratorResult = await GetLhaEntryIterator(pathResult.Value, recursive);
-        if (lhaEntryIteratorResult is { IsSuccess: true })
+
+        if (entryIteratorResult != null && entryIteratorResult.IsSuccess)
         {
-            using var lhaEntryIterator = lhaEntryIteratorResult.Value;
-            var initializeResult = await lhaEntryIterator.Initialize();
+            using var entryIterator = entryIteratorResult.Value;
+            var initializeResult = await entryIterator.Initialize();
             if (initializeResult.IsFaulted)
             {
                 return new Result<IEntryIterator>(initializeResult.Error);
             }
-            await ListEntries(lhaEntryIterator);
+            await ListEntries(entryIterator);
             return new Result();
         }
 
-        // lzx
-        var lzxEntryIteratorResult = await GetLzxEntryIterator(pathResult.Value, recursive);
-        if (lzxEntryIteratorResult is { IsSuccess: true })
-        {
-            using var lzxEntryIterator = lzxEntryIteratorResult.Value;
-            var initializeResult = await lzxEntryIterator.Initialize();
-            if (initializeResult.IsFaulted)
-            {
-                return new Result<IEntryIterator>(initializeResult.Error);
-            }
-            await ListEntries(lzxEntryIterator);
-            return new Result();
-        }
-
-        // adf
-        var adfEntryIteratorResult = await GetAdfEntryIterator(pathResult.Value, recursive);
-        if (adfEntryIteratorResult is { IsSuccess: true })
-        {
-            using var adfEntryIterator = adfEntryIteratorResult.Value;
-            var initializeResult = await adfEntryIteratorResult.Value.Initialize();
-            if (initializeResult.IsFaulted)
-            {
-                return new Result<IEntryIterator>(initializeResult.Error);
-            }
-            await ListEntries(adfEntryIterator);
-            return new Result();
-        }
-        
-        // iso
-        var iso9660EntryIteratorResult = await GetIso9660EntryIterator(pathResult.Value, recursive);
-        if (iso9660EntryIteratorResult is { IsSuccess: true })
-        {
-            using var iso9660EntryIterator = iso9660EntryIteratorResult.Value;
-            var initializeResult = await iso9660EntryIteratorResult.Value.Initialize();
-            if (initializeResult.IsFaulted)
-            {
-                return new Result<IEntryIterator>(initializeResult.Error);
-            }
-            await ListEntries(iso9660EntryIterator);
-            return new Result();
-        }
-        
         // floppy or disk
         var readableMediaResult = await commandHelper.GetReadableMedia(physicalDrives, pathResult.Value.MediaPath);
         if (readableMediaResult.IsFaulted)

--- a/src/Hst.Imager.Core/Commands/FsExtractCommand.cs
+++ b/src/Hst.Imager.Core/Commands/FsExtractCommand.cs
@@ -1,9 +1,9 @@
-﻿namespace Hst.Imager.Core.Commands;
+﻿using Hst.Imager.Core.MagicBytes;
+
+namespace Hst.Imager.Core.Commands;
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Extensions;
@@ -208,95 +208,39 @@ public class FsExtractCommand(
             recursive = true;
         }
         
-        // zip
-        var zipEntryIteratorResult = await GetZipEntryIterator(mediaResult.Value, recursive);
-        if (zipEntryIteratorResult != null && zipEntryIteratorResult.IsSuccess)
-        {
-            var initializeResult = await zipEntryIteratorResult.Value.Initialize();
-            return initializeResult.IsSuccess
-                ? new Result<IEntryIterator>(zipEntryIteratorResult.Value)
-                : new Result<IEntryIterator>(initializeResult.Error);
-        }
+        var dataType = await commandHelper.DetectDataType(mediaResult.Value.MediaPath);
 
-        // lha
-        var lhaEntryIteratorResult = await GetLhaEntryIterator(mediaResult.Value, recursive);
-        if (lhaEntryIteratorResult != null && lhaEntryIteratorResult.IsSuccess)
+        Result<IEntryIterator> entryIteratorResult = null;
+        switch (dataType)
         {
-            var initializeResult = await lhaEntryIteratorResult.Value.Initialize();
-            return initializeResult.IsSuccess
-                ? new Result<IEntryIterator>(lhaEntryIteratorResult.Value)
-                : new Result<IEntryIterator>(initializeResult.Error);
-        }
-
-        // lzx
-        var lzxEntryIteratorResult = await GetLzxEntryIterator(mediaResult.Value, recursive);
-        if (lzxEntryIteratorResult != null && lzxEntryIteratorResult.IsSuccess)
-        {
-            var initializeResult = await lzxEntryIteratorResult.Value.Initialize();
-            return initializeResult.IsSuccess
-                ? new Result<IEntryIterator>(lzxEntryIteratorResult.Value)
-                : new Result<IEntryIterator>(initializeResult.Error);
+            case DataType.Zip:
+                entryIteratorResult = await GetZipEntryIterator(mediaResult.Value, recursive);
+                break;
+            case DataType.Lha:
+                entryIteratorResult = await GetLhaEntryIterator(mediaResult.Value, recursive);
+                break;
+            case DataType.Lzx:
+                entryIteratorResult = await GetLzxEntryIterator(mediaResult.Value, recursive);
+                break;
+            case DataType.Lzw:
+                entryIteratorResult = await GetLzwEntryIterator(mediaResult.Value);
+                break;
+            case DataType.Adf:
+                entryIteratorResult = await GetAdfEntryIterator(mediaResult.Value, recursive);
+                break;
+            case DataType.Iso9660:
+                entryIteratorResult = await GetIso9660EntryIterator(mediaResult.Value, recursive);
+                break;
         }
         
-        // lzw
-        var lzwEntryIteratorResult = await GetLzwEntryIterator(mediaResult.Value);
-        if (lzwEntryIteratorResult != null && lzwEntryIteratorResult.IsSuccess)
+        if (entryIteratorResult != null && entryIteratorResult.IsSuccess)
         {
-            var initializeResult = await lzwEntryIteratorResult.Value.Initialize();
+            var initializeResult = await entryIteratorResult.Value.Initialize();
             return initializeResult.IsSuccess
-                ? new Result<IEntryIterator>(lzwEntryIteratorResult.Value)
-                : new Result<IEntryIterator>(initializeResult.Error);
-        }
-
-        // adf
-        var adfEntryIteratorResult = await GetAdfEntryIterator(mediaResult.Value, recursive);
-        if (adfEntryIteratorResult != null && adfEntryIteratorResult.IsSuccess)
-        {
-            var initializeResult = await adfEntryIteratorResult.Value.Initialize();
-            return initializeResult.IsSuccess
-                ? new Result<IEntryIterator>(adfEntryIteratorResult.Value)
-                : new Result<IEntryIterator>(initializeResult.Error);
-        }
-
-        // iso
-        var iso9660EntryIteratorResult = await GetIso9660EntryIterator(mediaResult.Value, recursive);
-        if (iso9660EntryIteratorResult != null && iso9660EntryIteratorResult.IsSuccess)
-        {
-            var initializeResult = await iso9660EntryIteratorResult.Value.Initialize();
-            return initializeResult.IsSuccess
-                ? new Result<IEntryIterator>(iso9660EntryIteratorResult.Value)
+                ? new Result<IEntryIterator>(entryIteratorResult.Value)
                 : new Result<IEntryIterator>(initializeResult.Error);
         }
 
         return new Result<IEntryIterator>(new Error($"File system at path '{path}' not supported"));
-    }
-
-    private static string TrimRootPath(string rootPath, string entryPath)
-    {
-        var trimmedEntryPath = rootPath.Length > 0 ? entryPath.Substring(rootPath.Length) : entryPath;
-
-        return trimmedEntryPath.StartsWith("\\") || trimmedEntryPath.StartsWith("/")
-            ? trimmedEntryPath.Substring(1)
-            : trimmedEntryPath;
-    }
-
-    private static string RemoveDiacritics(string text)
-    {
-        var normalizedString = text.Normalize(NormalizationForm.FormD);
-        var stringBuilder = new StringBuilder(capacity: normalizedString.Length);
-
-        for (int i = 0; i < normalizedString.Length; i++)
-        {
-            char c = normalizedString[i];
-            var unicodeCategory = CharUnicodeInfo.GetUnicodeCategory(c);
-            if (unicodeCategory != UnicodeCategory.NonSpacingMark)
-            {
-                stringBuilder.Append(c);
-            }
-        }
-
-        return stringBuilder
-            .ToString()
-            .Normalize(NormalizationForm.FormC);
     }
 }

--- a/src/Hst.Imager.Core/Commands/ICommandHelper.cs
+++ b/src/Hst.Imager.Core/Commands/ICommandHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Hst.Imager.Core.MagicBytes;
 
 namespace Hst.Imager.Core.Commands
 {
@@ -9,6 +10,7 @@ namespace Hst.Imager.Core.Commands
 
     public interface ICommandHelper : IDisposable
     {
+        Task<DataType> DetectDataType(string path);
         void ClearActiveMedias();
         void ClearActiveMedia(string path);
         void ClearActivePhysicalDrives();
@@ -19,7 +21,6 @@ namespace Hst.Imager.Core.Commands
         Task<Result<Media>> GetWritableMedia(IEnumerable<IPhysicalDrive> physicalDrives, string path, ModifierEnum? modifiers = null,
             long? size = null, bool create = false);
         long GetVhdSize(long size);
-        bool IsVhd(string path);
         bool IsZip(string path);
         bool IsGZip(string path);
         Task<DiskInfo> ReadDiskInfo(Media media,

--- a/src/Hst.Imager.Core/Commands/MbrCommands/MbrPartImportCommand.cs
+++ b/src/Hst.Imager.Core/Commands/MbrCommands/MbrPartImportCommand.cs
@@ -111,7 +111,7 @@
             OnDebugMessage(
                 $"Importing partition from source offset '{sourceOffset}' to destination offset '{destinationOffset}'");
 
-            var isVhd = commandHelper.IsVhd(destinationPath);
+            var isVhd = destinationMedia.Type == Media.MediaType.Vhd;
 
             using var streamCopier = new StreamCopier();
             streamCopier.DataProcessed += (_, e) =>

--- a/src/Hst.Imager.Core/Commands/OptimizeCommand.cs
+++ b/src/Hst.Imager.Core/Commands/OptimizeCommand.cs
@@ -20,11 +20,6 @@
         {
             OnInformationMessage($"Optimizing image file at '{path}'");
 
-            if (commandHelper.IsVhd(path))
-            {
-                return new Result(new UnsupportedImageError(path));
-            }
-
             OnDebugMessage($"Opening '{path}' as writable");
             
             var mediaResult = await commandHelper.GetWritableFileMedia(path);
@@ -35,6 +30,11 @@
 
             using var media = mediaResult.Value;
 
+            if (media.Type != Media.MediaType.Raw)
+            {
+                return new Result(new UnsupportedImageError(path));
+            }
+            
             OnDebugMessage($"Media size '{media.Size}'");
         
             var diskInfo = await commandHelper.ReadDiskInfo(media);

--- a/src/Hst.Imager.Core/Commands/RdbPartCopyCommand.cs
+++ b/src/Hst.Imager.Core/Commands/RdbPartCopyCommand.cs
@@ -1,6 +1,7 @@
 ﻿using Hst.Amiga;
 using Hst.Amiga.Extensions;
 using Hst.Core.Extensions;
+using Hst.Imager.Core.Models;
 
 namespace Hst.Imager.Core.Commands
 {
@@ -12,7 +13,7 @@ namespace Hst.Imager.Core.Commands
     using Amiga.RigidDiskBlocks;
     using Extensions;
     using Hst.Core;
-    using Hst.Imager.Core.Helpers;
+    using Helpers;
     using Microsoft.Extensions.Logging;
 
     public class RdbPartCopyCommand : CommandBase
@@ -169,7 +170,7 @@ namespace Hst.Imager.Core.Commands
                                           destinationRigidDiskBlock.BlockSize;
             var destinationOffset = (long)destinationPartitionBlock.LowCyl * destinationCylinderSize;
             
-            var isVhd = commandHelper.IsVhd(destinationPath);
+            var isVhd = destinationMedia.Type == Media.MediaType.Vhd;
 
             OnDebugMessage($"Copying partition from source offset '{sourceOffset}' to destination offset '{destinationOffset}'");
             

--- a/src/Hst.Imager.Core/Commands/RdbPartImportCommand.cs
+++ b/src/Hst.Imager.Core/Commands/RdbPartImportCommand.cs
@@ -1,4 +1,6 @@
-﻿namespace Hst.Imager.Core.Commands
+﻿using Hst.Imager.Core.Models;
+
+namespace Hst.Imager.Core.Commands
 {
     using System;
     using System.Collections.Generic;
@@ -9,7 +11,7 @@
     using Amiga.RigidDiskBlocks;
     using Extensions;
     using Hst.Core;
-    using Hst.Imager.Core.Helpers;
+    using Helpers;
     using Microsoft.Extensions.Logging;
 
     public class RdbPartImportCommand : CommandBase
@@ -128,7 +130,7 @@
 
             OnDebugMessage($"Importing partition from source offset '{sourceOffset}' to destination offset '{destinationOffset}'");
 
-            var isVhd = commandHelper.IsVhd(destinationPath);
+            var isVhd = destinationMedia.Type == Media.MediaType.Vhd;
 
             using var streamCopier = new StreamCopier();
             streamCopier.DataProcessed += (_, e) =>

--- a/src/Hst.Imager.Core/Commands/ReadCommand.cs
+++ b/src/Hst.Imager.Core/Commands/ReadCommand.cs
@@ -102,10 +102,8 @@ namespace Hst.Imager.Core.Commands
             using var destMedia = destMediaResult.Value;
             var destStream = MediaHelper.GetStreamFromMedia(destMedia);
 
-            var isVhd = commandHelper.IsVhd(destinationPath);
-            var isZip = commandHelper.IsZip(destinationPath);
-            var isGZip = commandHelper.IsGZip(destinationPath);
-            if (!isVhd && !isZip && !isGZip)
+            var isVhd = destMedia.Type == Media.MediaType.Vhd;
+            if (destMedia.Type == Media.MediaType.Raw)
             {
                 destStream.SetLength(readSize);
             }

--- a/src/Hst.Imager.Core/Commands/TransferCommand.cs
+++ b/src/Hst.Imager.Core/Commands/TransferCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Hst.Imager.Core.Helpers;
+using Hst.Imager.Core.Models;
 using Hst.Imager.Core.SparseFiles;
 
 namespace Hst.Imager.Core.Commands
@@ -144,7 +145,7 @@ namespace Hst.Imager.Core.Commands
             streamCopier.SrcError += (_, args) => OnSrcError(args);
             streamCopier.DestError += (_, args) => OnDestError(args);
             
-            var isVhd = commandHelper.IsVhd(destinationPath);
+            var isVhd = destMedia.Type == Media.MediaType.Vhd;
             
             var isSparseFile = false;
             if (sparseFiles)

--- a/src/Hst.Imager.Core/Extensions/ArrayExtensions.cs
+++ b/src/Hst.Imager.Core/Extensions/ArrayExtensions.cs
@@ -15,9 +15,4 @@ public static class ArrayExtensions
         var uintBytes = BitConverter.GetBytes(value);
         Array.Copy(uintBytes, 0, data, offset, uintBytes.Length);
     }
-
-    public static bool HasMagicNumber(this byte[] data, byte[] magicNumberBytes, int offset = 0)
-    {
-        return MagicBytes.HasMagicNumber(magicNumberBytes, data, offset);
-    }
 }

--- a/src/Hst.Imager.Core/Helpers/MediaHelper.cs
+++ b/src/Hst.Imager.Core/Helpers/MediaHelper.cs
@@ -9,8 +9,8 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Hst.Core;
-using Hst.Core.IO;
 using Hst.Imager.Core.Extensions;
+using Hst.Imager.Core.MagicBytes;
 
 namespace Hst.Imager.Core.Helpers
 {
@@ -39,10 +39,15 @@ namespace Hst.Imager.Core.Helpers
             var firstChunk = new byte[1024 * 1024];
             await media.Stream.FillAsync(firstChunk, 0, firstChunk.Length);
 
-            // return compressed vhd, if vhd magic number is present in first chunk
-            return MagicBytes.HasMagicNumber(MagicBytes.VhdMagicNumber, firstChunk, 0)
-                ? CompressedVhd(media.Stream, firstChunk)
-                : CompressedImg(media.Stream, firstChunk);
+            // return compressed vhd, if first chunk is vhd data type
+            if (MagicBytesRegister.Instance.TryResolve(firstChunk, out var dataType) &&
+                dataType == DataType.Vhd)
+            {
+                return CompressedVhd(media.Stream, firstChunk);
+            }
+            
+            // return compressed img
+            return CompressedImg(media.Stream, firstChunk);
         }
 
         private static VirtualDisk CompressedVhd(Stream stream, byte[] firstChunk) => 
@@ -281,6 +286,10 @@ namespace Hst.Imager.Core.Helpers
                 ? new Result<Tuple<long, long>>(new Error($"Partition number {partitionNumber} not found"))
                 : new Result<Tuple<long, long>>(new Tuple<long, long>(partition.StartOffset, partition.Size));
         }
+        
+        public static bool IsVhd(string path) => path.EndsWith(".vhd", StringComparison.OrdinalIgnoreCase);
+
+        
     }
 
     public class PiStormRdbMediaResult

--- a/src/Hst.Imager.Core/Hst.Imager.Core.csproj
+++ b/src/Hst.Imager.Core/Hst.Imager.Core.csproj
@@ -3,7 +3,7 @@
     <ItemGroup>
       <PackageReference Include="Hst.Amiga" Version="0.6.222" />
       <PackageReference Include="hst.compression" Version="0.4.85" />
-      <PackageReference Include="Hst.Core" Version="0.4.85" />
+      <PackageReference Include="Hst.Core" Version="0.4.87" />
       <PackageReference Include="LTRData.DiscUtils.Containers" Version="1.0.74" />
       <PackageReference Include="LTRData.DiscUtils.ExFat" Version="1.0.74" />
       <PackageReference Include="LTRData.DiscUtils.Fat" Version="1.0.74" />

--- a/src/Hst.Imager.Core/Hst.Imager.Core.csproj
+++ b/src/Hst.Imager.Core/Hst.Imager.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-      <PackageReference Include="Hst.Amiga" Version="0.6.221" />
+      <PackageReference Include="Hst.Amiga" Version="0.6.222" />
       <PackageReference Include="hst.compression" Version="0.4.85" />
       <PackageReference Include="Hst.Core" Version="0.4.85" />
       <PackageReference Include="LTRData.DiscUtils.Containers" Version="1.0.74" />

--- a/src/Hst.Imager.Core/MagicBytes/DataType.cs
+++ b/src/Hst.Imager.Core/MagicBytes/DataType.cs
@@ -1,0 +1,36 @@
+﻿namespace Hst.Imager.Core.MagicBytes;
+
+public enum DataType
+{
+    Unknown,
+    Vhd,
+
+    /// <summary>
+    /// Rigid Disk Block.
+    /// </summary>
+    Rdb,
+    Iso9660,
+    Adf,
+
+    /// <summary>
+    /// Master Boot Record.
+    /// </summary>
+    Mbr,
+    
+    /// <summary>
+    /// Guid Partition Table.
+    /// </summary>
+    Gpt,
+    Lha,
+    Lzx,
+    Hunk,
+    Lzw,
+    Zip,
+    Xz,
+    
+    /// <summary>
+    /// Gzip compressed. 
+    /// </summary>
+    Gzip,
+    Rar
+}

--- a/src/Hst.Imager.Core/MagicBytes/Identifier.cs
+++ b/src/Hst.Imager.Core/MagicBytes/Identifier.cs
@@ -1,0 +1,3 @@
+﻿namespace Hst.Imager.Core.MagicBytes;
+
+public record Identifier(int Offset, byte[] MagicBytes, DataType DataType);

--- a/src/Hst.Imager.Core/MagicBytes/KnownMagicBytes.cs
+++ b/src/Hst.Imager.Core/MagicBytes/KnownMagicBytes.cs
@@ -1,56 +1,56 @@
-﻿namespace Hst.Imager.Core;
+﻿namespace Hst.Imager.Core.MagicBytes;
 
-public static class MagicBytes
+public static class KnownMagicBytes
 {
     /// <summary>
     /// "conectix" at offset 0 (Windows Virtual PC Virtual Hard Disk file format)
     /// </summary>
-    public static readonly byte[] VhdMagicNumber = [0x63, 0x6F, 0x6E, 0x65, 0x63, 0x74, 0x69, 0x78];
+    public static readonly byte[] VhdMagicBytes = [0x63, 0x6F, 0x6E, 0x65, 0x63, 0x74, 0x69, 0x78];
 
     /// <summary>
     /// "RDSK" at sector 0-15 (Amiga Rigid Disk Block)
     /// </summary>
-    public static readonly byte[] RdbMagicNumber = [0x52, 0x44, 0x53, 0x4B];
+    public static readonly byte[] RdbMagicBytes = [0x52, 0x44, 0x53, 0x4B];
 
     /// <summary>
     /// CD001 at offset 0x8001, 0x8801 or 0x9001 (ISO9660 CD/DVD image file)
     /// </summary>
-    public static readonly byte[] Iso9660MagicNumber = [0x43, 0x44, 0x30, 0x30, 0x31];
+    public static readonly byte[] Iso9660MagicBytes = [0x43, 0x44, 0x30, 0x30, 0x31];
 
     /// <summary>
-    /// "DOS" at offset 0 (Amiga Disk File)
+    /// "DOS" at offset 0 (Amiga Disk File) 3 bytes followed by 1 byte of value 0-7 for dostype
     /// </summary>
-    public static readonly byte[] AdfDosMagicNumber = [0x44, 0x4f, 0x53];
+    public static readonly byte[] AdfDosMagicBytes = [0x44, 0x4f, 0x53];
 
     /// <summary>
     /// MBR boot signature at offset 510 / 0x1fe (Master Boot Record)
     /// </summary>
-    public static readonly byte[] MbrMagicNumber = [0x55, 0xaa];
+    public static readonly byte[] MbrMagicNumbers = [0x55, 0xaa];
 
     /// <summary>
     /// GPT signature at offset 0 / 0x0 in LBA 1 / sector 1 (Guid Partition Table)
     /// </summary>
-    public static readonly byte[] GptMagicNumber = [0x45, 0x46, 0x49, 0x20, 0x50, 0x41, 0x52, 0x54];
+    public static readonly byte[] GptMagicNumbers = [0x45, 0x46, 0x49, 0x20, 0x50, 0x41, 0x52, 0x54];
     
     /// <summary>
     /// "-lh" at offset 2 (Lha archive)
     /// </summary>
-    public static readonly byte[] LhaMagicNumber = [0x2D, 0x6C, 0x68];
+    public static readonly byte[] LhaMagicNumbers = [0x2D, 0x6C, 0x68];
     
     /// <summary>
     /// "LZX" at offset 0 (Lzx archive)
     /// </summary>
-    public static readonly byte[] LzxMagicNumber = [0x4C, 0x5A, 0x58]; 
+    public static readonly byte[] LzxMagicNumbers = [0x4C, 0x5A, 0x58]; 
 
     /// <summary>
     /// Amiga Hunk header at offset 0
     /// </summary>
-    public static readonly byte[] HunkMagicNumber = [0x0, 0x0, 0x03, 0xf3]; 
+    public static readonly byte[] HunkMagicNumbers = [0x0, 0x0, 0x03, 0xf3]; 
 
     /// <summary>
     /// Lzw compression header offset 0 (.Z archive)
     /// </summary>
-    public static readonly byte[] LzwMagicNumber = [0x1f, 0x9d];
+    public static readonly byte[] LzwMagicNumbers = [0x1f, 0x9d];
     
     /// <summary>
     /// "PK" at offset 0 (Zip archive, normal archive)
@@ -80,21 +80,4 @@ public static class MagicBytes
     /// </summary>
     public static readonly byte[] RarMagicNumber500 = [0x52, 0x61, 0x72, 0x21, 0x1a, 0x07, 0x1, 0x0]; 
 
-    public static bool HasMagicNumber(byte[] magicNumber, byte[] data, int dataOffset)
-    {
-        if (dataOffset >= data.Length)
-        {
-            return false;
-        }
-        
-        for (var i = 0; i < magicNumber.Length && dataOffset + i < data.Length; i++)
-        {
-            if (magicNumber[i] != data[dataOffset + i])
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
 }

--- a/src/Hst.Imager.Core/MagicBytes/MagicBytesRegister.cs
+++ b/src/Hst.Imager.Core/MagicBytes/MagicBytesRegister.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Hst.Imager.Core.MagicBytes;
+
+public class MagicBytesRegister
+{
+    private readonly List<Identifier> identifiers;
+    private static readonly Lazy<MagicBytesRegister> SingletonInstance =
+        new Lazy<MagicBytesRegister>(
+            () =>
+            {
+                var register = new MagicBytesRegister();
+                register.AddDefault();
+                return register;
+            }, LazyThreadSafetyMode.PublicationOnly);
+
+    public MagicBytesRegister()
+    {
+        identifiers = new List<Identifier>();
+    }
+
+    public IReadOnlyList<Identifier> Identifiers => identifiers;
+    
+    public static MagicBytesRegister Instance => SingletonInstance.Value;
+    
+    /// <summary>
+    /// Add default magic bytes to the registers list of identifiers.
+    /// </summary>
+    public void AddDefault()
+    {
+        identifiers.Add(new Identifier(0, KnownMagicBytes.VhdMagicBytes, DataType.Vhd));
+
+        for (var sector = 0; sector <= 15; sector++)
+        {
+            identifiers.Add(new Identifier(sector * 512, KnownMagicBytes.RdbMagicBytes, DataType.Rdb));
+        }
+        
+        identifiers.Add(new Identifier(0x8001, KnownMagicBytes.Iso9660MagicBytes, DataType.Iso9660));
+        identifiers.Add(new Identifier(0x8801, KnownMagicBytes.Iso9660MagicBytes, DataType.Iso9660));
+        identifiers.Add(new Identifier(0x9001, KnownMagicBytes.Iso9660MagicBytes, DataType.Iso9660));
+
+        for (byte dos = 0; dos <= 7; dos++)
+        {
+            identifiers.Add(new Identifier(0, KnownMagicBytes.AdfDosMagicBytes.Concat([dos]).ToArray(), DataType.Adf));
+        }
+        
+        identifiers.Add(new Identifier(0x1fe, KnownMagicBytes.MbrMagicNumbers, DataType.Mbr));
+        
+        identifiers.Add(new Identifier(0x200, KnownMagicBytes.GptMagicNumbers, DataType.Gpt));
+        
+        identifiers.Add(new Identifier(2, KnownMagicBytes.LhaMagicNumbers, DataType.Lha));
+        
+        identifiers.Add(new Identifier(0, KnownMagicBytes.LzxMagicNumbers, DataType.Lzx));
+        
+        identifiers.Add(new Identifier(0, KnownMagicBytes.HunkMagicNumbers, DataType.Hunk));
+        
+        identifiers.Add(new Identifier(0, KnownMagicBytes.LzwMagicNumbers, DataType.Lzw));
+        
+        identifiers.Add(new Identifier(0, KnownMagicBytes.ZipMagicNumber1, DataType.Zip));
+        identifiers.Add(new Identifier(0, KnownMagicBytes.ZipMagicNumber2, DataType.Zip));
+        identifiers.Add(new Identifier(0, KnownMagicBytes.ZipMagicNumber3, DataType.Zip));
+        
+        identifiers.Add(new Identifier(0, KnownMagicBytes.ZxHeader, DataType.Xz));
+
+        identifiers.Add(new Identifier(0, KnownMagicBytes.GzHeader, DataType.Gzip));
+        
+        identifiers.Add(new Identifier(0, KnownMagicBytes.RarMagicNumber150, DataType.Rar));
+        identifiers.Add(new Identifier(0, KnownMagicBytes.RarMagicNumber500, DataType.Rar));
+    }
+}

--- a/src/Hst.Imager.Core/MagicBytes/MagicBytesRegisterExtensions.cs
+++ b/src/Hst.Imager.Core/MagicBytes/MagicBytesRegisterExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System.Linq;
+
+namespace Hst.Imager.Core.MagicBytes;
+
+public static class MagicBytesRegisterExtensions
+{
+    private static bool HasMagicNumber(byte[] magicNumbers, byte[] data, int offset)
+    {
+        if (offset >= data.Length)
+        {
+            return false;
+        }
+        
+        for (var i = 0; i < magicNumbers.Length && offset + i < data.Length; i++)
+        {
+            if (magicNumbers[i] != data[offset + i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static bool TryResolve(this MagicBytesRegister register, byte[] data, out DataType dataType)
+    {
+        var identifier = register.Identifiers.FirstOrDefault(x => HasMagicNumber(x.MagicBytes, data, x.Offset));
+
+        dataType = identifier?.DataType ?? DataType.Unknown;
+        
+        return identifier != null;
+    }
+}


### PR DESCRIPTION
This PR fixes an issue with pfs3 overwriting files causing it to hang with latest Hst Amiga package. The cache layer has also been fixed to delete cache files when a command has completed using .vhd image files. The progressbar has been fixed and is displayed again when the cache is flushing to physical disk or image file with latest Hst Core packages. Using .vhd image files with extension other that .vhd (like AmiKit) has been fixed by Hst Imager using magic bytes to detect file type instead of filename extensions.