### PR TITLE
Fs del command fixes

### DIFF
--- a/src/Hst.Imager.ConsoleApp/CommandHandler.cs
+++ b/src/Hst.Imager.ConsoleApp/CommandHandler.cs
@@ -685,6 +685,14 @@ namespace Hst.Imager.ConsoleApp
                 await GetPhysicalDrives(), path);
             await Execute(command);
         }
+
+        public static async Task FsDelete(string path)
+        {
+            using var commandHelper = GetCommandHelper(useCache: true);
+            var command = new FsDelCommand(GetLogger<FsDelCommand>(), commandHelper,
+                await GetPhysicalDrives(), path);
+            await Execute(command);
+        }
         
         public static async Task FsCopy(string srcPath, string destPath, bool recursive, bool skipAttributes, bool quiet,
             UaeMetadata uaeMetadata, bool makeDirectory, bool forceOverwrite)

--- a/src/Hst.Imager.ConsoleApp/FsCommandFactory.cs
+++ b/src/Hst.Imager.ConsoleApp/FsCommandFactory.cs
@@ -13,6 +13,7 @@ public static class FsCommandFactory
         command.AddCommand(CreateFsCopy());
         command.AddCommand(CreateFsExtract());
         command.AddCommand(CreateFsMkDir());
+        command.AddCommand(CreateFsDelete());
 
         return command;
     }
@@ -34,7 +35,6 @@ public static class FsCommandFactory
             getDefaultValue: () => UaeMetadata.UaeFsDb);
         
         var command = new Command("dir", "List files and subdirectories in a directory.");
-        command.AddAlias("d");
         command.SetHandler(CommandHandler.FsDir, pathArgument, recursiveOption, uaeMetadataOption, CommandFactory.FormatOption);
         command.AddArgument(pathArgument);
         command.AddOption(recursiveOption);
@@ -165,6 +165,20 @@ public static class FsCommandFactory
 
         var command = new Command("mkdir", "Create a directory.");
         command.SetHandler(CommandHandler.FsMkDir, pathArgument);
+        command.AddArgument(pathArgument);
+
+        return command;
+    }
+    
+    private static Command CreateFsDelete()
+    {
+        var pathArgument = new Argument<string>(
+            name: "Path",
+            description: "Path to directory or file to delete locally, in physical drive or image file.");
+
+        var command = new Command("delete", "Create a directory.");
+        command.AddAlias("del");
+        command.SetHandler(CommandHandler.FsDelete, pathArgument);
         command.AddArgument(pathArgument);
 
         return command;

--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDelCommandWithAdf.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDelCommandWithAdf.cs
@@ -134,4 +134,40 @@ public class GivenFsDelCommandWithAdf
         ];
         Assert.Equal(expectedEntries, entries.Select(x => x.Name).ToArray());
     }
+
+    [Fact]
+    public async Task When_DeletingRootWithWildcard_Then_AllDirectoriesAndFilesAreDeleted()
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.adf";
+        var deletePath = Path.Combine(mediaPath, "*");
+        const UaeMetadata uaeMetadata = UaeMetadata.UaeFsDb;
+
+        // arrange - test command helper
+        using var testCommandHelper = new TestCommandHelper();
+
+        // arrange - create adf formatted disk with directories and files
+        await AdfTestHelper.CreateFormattedAdfDisk(testCommandHelper, mediaPath);
+        await AdfTestHelper.CreateDirectoriesAndFiles(testCommandHelper, mediaPath);
+
+        // arrange - create fs del command
+        var fsDelCommand = new FsDelCommand(new NullLogger<FsDelCommand>(), testCommandHelper, [],
+            deletePath, uaeMetadata);
+        
+        // act - execute fs del command
+        var result = await fsDelCommand.Execute(CancellationToken.None);
+        
+        // assert - result is success
+        Assert.True(result.IsSuccess);
+        
+        // arrange - clear active medias to ensure changes to media is flushed
+        testCommandHelper.ClearActiveMedias();
+        
+        // assert - root directory is empty
+        var entries = (await AdfTestHelper
+                .GetEntriesFromFileSystemVolume(testCommandHelper, mediaPath, []))
+            .OrderBy(x => x.Name)
+            .ToList();
+        Assert.Empty(entries);
+    }
 }

--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDelCommandWithGpt.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDelCommandWithGpt.cs
@@ -143,4 +143,43 @@ public class GivenFsDelCommandWithGpt
         ];
         Assert.Equal(expectedEntries, entries.Select(x => x.Name).ToArray());
     }
+    
+    [Fact]
+    public async Task When_DeletingRootWithWildcard_Then_AllDirectoriesAndFilesAreDeleted()
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.vhd";
+        var deletePath = Path.Combine(mediaPath, "gpt", "1", "*");
+        const UaeMetadata uaeMetadata = UaeMetadata.UaeFsDb;
+
+        // arrange - test command helper
+        using var testCommandHelper = new TestCommandHelper();
+
+        // arrange - add media
+        testCommandHelper.AddTestMedia(mediaPath, 0);
+
+        // arrange - create gpt fat formatted disk with directories and files
+        await TestHelper.CreateGptFatFormattedDisk(testCommandHelper, mediaPath);
+        await GptTestHelper.CreateDirectoriesAndFiles(testCommandHelper, mediaPath);
+
+        // arrange - create fs del command
+        var fsDelCommand = new FsDelCommand(new NullLogger<FsDelCommand>(), testCommandHelper, [],
+            deletePath, uaeMetadata);
+        
+        // act - execute fs del command
+        var result = await fsDelCommand.Execute(CancellationToken.None);
+        
+        // assert - result is success
+        Assert.True(result.IsSuccess);
+        
+        // arrange - clear active medias to ensure changes to media is flushed
+        testCommandHelper.ClearActiveMedias();
+        
+        // assert - root directory is empty
+        var entries = (await GptTestHelper
+                .GetEntriesFromFileSystemVolume(testCommandHelper, mediaPath, 0, []))
+            .OrderBy(x => x.Name)
+            .ToList();
+        Assert.Empty(entries);
+    }
 }

--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDelCommandWithLocalDirectory.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDelCommandWithLocalDirectory.cs
@@ -108,7 +108,7 @@ public class GivenFsDelCommandWithLocalDirectory
     public async Task When_DeletingADirectory_Then_DirectoryIsDeleted()
     {
         // arrange - paths
-        var mediaPath = $"{Guid.NewGuid()}.vhd";
+        var mediaPath = Guid.NewGuid().ToString();
         var deletePath = Path.Combine(mediaPath, "dir1");
         const UaeMetadata uaeMetadata = UaeMetadata.UaeFsDb;
 
@@ -143,6 +143,47 @@ public class GivenFsDelCommandWithLocalDirectory
                 Path.Combine(mediaPath, "dir2")
             ];
             Assert.Equal(expectedEntries, entries);
+        }
+        finally
+        {
+            TestHelper.DeletePaths(mediaPath);
+        }
+    }
+    
+    [Fact]
+    public async Task When_DeletingRootWithWildcard_Then_AllDirectoriesAndFilesAreDeleted()
+    {
+        // arrange - paths
+        var mediaPath = Guid.NewGuid().ToString();
+        var deletePath = Path.Combine(mediaPath, "*");
+        const UaeMetadata uaeMetadata = UaeMetadata.UaeFsDb;
+
+        try
+        {
+            // arrange - test command helper
+            using var testCommandHelper = new TestCommandHelper();
+
+            // arrange - create local directory with directories and files
+            await LocalTestHelper.CreateDirectoriesAndFiles(mediaPath);
+
+            // arrange - create fs del command
+            var fsDelCommand = new FsDelCommand(new NullLogger<FsDelCommand>(), testCommandHelper, [],
+                deletePath, uaeMetadata);
+            
+            // act - execute fs del command
+            var result = await fsDelCommand.Execute(CancellationToken.None);
+            
+            // assert - result is success
+            Assert.True(result.IsSuccess);
+            
+            // arrange - clear active medias to ensure changes to media is flushed
+            testCommandHelper.ClearActiveMedias();
+            
+            // assert - root directory is empty
+            var entries = Directory.GetFileSystemEntries(mediaPath, "*.*", SearchOption.TopDirectoryOnly)
+                .OrderBy(x => x)
+                .ToList();
+            Assert.Empty(entries);
         }
         finally
         {

--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDelCommandWithMbr.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDelCommandWithMbr.cs
@@ -143,4 +143,43 @@ public class GivenFsDelCommandWithMbr
         ];
         Assert.Equal(expectedEntries, entries.Select(x => x.Name).ToArray());
     }
+    
+    [Fact]
+    public async Task When_DeletingRootWithWildcard_Then_AllDirectoriesAndFilesAreDeleted()
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.vhd";
+        var deletePath = Path.Combine(mediaPath, "mbr", "1", "*");
+        const UaeMetadata uaeMetadata = UaeMetadata.UaeFsDb;
+
+        // arrange - test command helper
+        using var testCommandHelper = new TestCommandHelper();
+
+        // arrange - add media
+        testCommandHelper.AddTestMedia(mediaPath, 0);
+
+        // arrange - create mbr fat formatted disk with directories and files
+        await TestHelper.CreateMbrFatFormattedDisk(testCommandHelper, mediaPath);
+        await MbrTestHelper.CreateDirectoriesAndFiles(testCommandHelper, mediaPath);
+
+        // arrange - create fs del command
+        var fsDelCommand = new FsDelCommand(new NullLogger<FsDelCommand>(), testCommandHelper, [],
+            deletePath, uaeMetadata);
+        
+        // act - execute fs del command
+        var result = await fsDelCommand.Execute(CancellationToken.None);
+        
+        // assert - result is success
+        Assert.True(result.IsSuccess);
+        
+        // arrange - clear active medias to ensure changes to media is flushed
+        testCommandHelper.ClearActiveMedias();
+        
+        // assert - root directory is empty
+        var entries = (await MbrTestHelper
+                .GetEntriesFromFileSystemVolume(testCommandHelper, mediaPath, 0, []))
+            .OrderBy(x => x.Name)
+            .ToList();
+        Assert.Empty(entries);
+    }
 }

--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDelCommandWithRdbDos3.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDelCommandWithRdbDos3.cs
@@ -143,4 +143,43 @@ public class GivenFsDelCommandWithRdbDos3
         ];
         Assert.Equal(expectedEntries, entries.Select(x => x.Name).ToArray());
     }
+
+    [Fact]
+    public async Task When_DeletingRootWithWildcard_Then_AllDirectoriesAndFilesAreDeleted()
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.vhd";
+        var deletePath = Path.Combine(mediaPath, "rdb", "1", "*");
+        const UaeMetadata uaeMetadata = UaeMetadata.UaeFsDb;
+
+        // arrange - test command helper
+        using var testCommandHelper = new TestCommandHelper();
+
+        // arrange - add media
+        testCommandHelper.AddTestMedia(mediaPath, 0);
+
+        // arrange - create rdb dos3 formatted disk with directories and files
+        await TestHelper.CreateDos3FormattedDisk(testCommandHelper, mediaPath);
+        await RdbTestHelper.CreateDirectoriesAndFiles(testCommandHelper, mediaPath);
+
+        // arrange - create fs del command
+        var fsDelCommand = new FsDelCommand(new NullLogger<FsDelCommand>(), testCommandHelper, [],
+            deletePath, uaeMetadata);
+        
+        // act - execute fs del command
+        var result = await fsDelCommand.Execute(CancellationToken.None);
+        
+        // assert - result is success
+        Assert.True(result.IsSuccess);
+        
+        // arrange - clear active medias to ensure changes to media is flushed
+        testCommandHelper.ClearActiveMedias();
+        
+        // assert - root directory is empty
+        var entries = (await RdbTestHelper
+                .GetEntriesFromFileSystemVolume(testCommandHelper, mediaPath, 0, []))
+            .OrderBy(x => x.Name)
+            .ToList();
+        Assert.Empty(entries);
+    }
 }

--- a/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDelCommandWithRdbPfs3.cs
+++ b/src/Hst.Imager.Core.Tests/CommandTests/FsCommandTests/GivenFsDelCommandWithRdbPfs3.cs
@@ -143,4 +143,43 @@ public class GivenFsDelCommandWithRdbPfs3
         ];
         Assert.Equal(expectedEntries, entries.Select(x => x.Name).ToArray());
     }
+    
+    [Fact]
+    public async Task When_DeletingRootWithWildcard_Then_AllDirectoriesAndFilesAreDeleted()
+    {
+        // arrange - paths
+        var mediaPath = $"{Guid.NewGuid()}.vhd";
+        var deletePath = Path.Combine(mediaPath, "rdb", "1", "*");
+        const UaeMetadata uaeMetadata = UaeMetadata.UaeFsDb;
+
+        // arrange - test command helper
+        using var testCommandHelper = new TestCommandHelper();
+
+        // arrange - add media
+        testCommandHelper.AddTestMedia(mediaPath, 0);
+
+        // arrange - create rdb pfs3 formatted disk with directories and files
+        await TestHelper.CreatePfs3FormattedDisk(testCommandHelper, mediaPath);
+        await RdbTestHelper.CreateDirectoriesAndFiles(testCommandHelper, mediaPath);
+
+        // arrange - create fs del command
+        var fsDelCommand = new FsDelCommand(new NullLogger<FsDelCommand>(), testCommandHelper, [],
+            deletePath, uaeMetadata);
+        
+        // act - execute fs del command
+        var result = await fsDelCommand.Execute(CancellationToken.None);
+        
+        // assert - result is success
+        Assert.True(result.IsSuccess);
+        
+        // arrange - clear active medias to ensure changes to media is flushed
+        testCommandHelper.ClearActiveMedias();
+        
+        // assert - root directory is empty
+        var entries = (await RdbTestHelper
+                .GetEntriesFromFileSystemVolume(testCommandHelper, mediaPath, 0, []))
+            .OrderBy(x => x.Name)
+            .ToList();
+        Assert.Empty(entries);
+    }
 }

--- a/src/Hst.Imager.Core/Commands/AmigaVolumeEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/AmigaVolumeEntryIterator.cs
@@ -32,7 +32,7 @@ public class AmigaVolumeEntryIterator(
     bool recursive)
     : IEntryIterator
 {
-    private readonly IMediaPath mediaPath = MediaPath.AmigaOsPath;
+    private readonly IMediaPath mediaPath = Core.PathComponents.MediaPath.AmigaOsPath;
     private PathComponentMatcher pathComponentMatcher;
     private readonly Stack<Entry> nextEntries = new();
     private bool isFirst = true;
@@ -41,6 +41,8 @@ public class AmigaVolumeEntryIterator(
     private List<string> currentPathComponents = new(10);
     private uint currentDirectoryBlockNumber = fileSystemVolume.CurrentDirectoryBlockNumber;
 
+    public IMediaPath MediaPath => mediaPath;
+    
     public PartitionTableType PartitionTableType => partitionTableType;
     public int PartitionNumber => partitionNumber;
 

--- a/src/Hst.Imager.Core/Commands/DirectoryEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/DirectoryEntryIterator.cs
@@ -46,6 +46,8 @@ public class DirectoryEntryIterator : IEntryIterator
         rootPathComponents = PathHelper.Split(rootPath);
     }
 
+    public IMediaPath MediaPath => Core.PathComponents.MediaPath.GenericMediaPath;
+
     public async Task<Result> Initialize()
     {
         if (rootPathComponents.Length == 0)

--- a/src/Hst.Imager.Core/Commands/FileSystemEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/FileSystemEntryIterator.cs
@@ -34,7 +34,7 @@ public class FileSystemEntryIterator(
     string[] rootPathComponents,
     bool recursive) : IEntryIterator
 {
-    private readonly IMediaPath mediaPath = MediaPath.GenericMediaPath;
+    private readonly IMediaPath mediaPath = Core.PathComponents.MediaPath.GenericMediaPath;
     private PathComponentMatcher pathComponentMatcher;
     private readonly Stack<Entry> nextEntries = new();
     private bool isFirst = true;
@@ -85,6 +85,8 @@ public class FileSystemEntryIterator(
     }
 
     public void Dispose() => Dispose(true);
+
+    public IMediaPath MediaPath => mediaPath;
 
     public Task<Result> Initialize()
     {

--- a/src/Hst.Imager.Core/Commands/FsDelCommand.cs
+++ b/src/Hst.Imager.Core/Commands/FsDelCommand.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Hst.Core;
 using Hst.Imager.Core.Caching;
+using Hst.Imager.Core.Extensions;
 using Hst.Imager.Core.Helpers;
 using Hst.Imager.Core.MagicBytes;
 using Hst.Imager.Core.Models;
@@ -33,13 +35,19 @@ public class FsDelCommand(
         
         using var entryIterator = entryIteratorResult.Value;
 
+        var stopwatch = new Stopwatch();
+
+        stopwatch.Start();
+
+        OnInformationMessage($"Deleting path '{path}'");
+
         var entries = new List<Entry>();
 
         while (await entryIterator.Next())
         {
             var entry = entryIterator.Current;
             
-            // skip directory entries when there are no entry path components or when it is a single file.
+            // skip directory entries when there are no entry path components or when it's a single file.
             if (entry.Type == EntryType.Dir &&
                 (entryIterator.IsSingleFileEntryNext || entry.RelativePathComponents.Length == 0))
             {
@@ -49,21 +57,67 @@ public class FsDelCommand(
             entries.Add(entry);
         }
 
-        // get writer to delete
-        foreach (var entry in entries)
+        var filesCount = 0;
+        var dirsCount = 0;
+        var totalBytes = 0L;
+
+        var dirPathComponents = entryIterator.DirPathComponents.Length > 0
+            ? new[] { entryIterator.DirPathComponents[^1] }
+            : [];
+        
+        // delete entries starting with the longest path to ensure files are deleted before their parent directories
+        foreach (var entry in entries.OrderByDescending(e => e.RelativePathComponents.Length))
         {
-            // delete
+            switch (entry.Type)
+            {
+                case EntryType.Dir:
+                case EntryType.LinkDir:
+                    dirsCount++;
+                    break;
+                case EntryType.File:
+                    filesCount++;
+                    totalBytes += entry.Size;
+                    break;
+                case EntryType.LinkFile:
+                    filesCount++;
+                    break;
+            }
+            
+            var pathComponents = entryIterator.IsSingleFileEntryNext
+                ? entry.RelativePathComponents
+                : dirPathComponents.Concat(entry.RelativePathComponents).ToArray();
+            
+            OnInformationMessage($"{entryIterator.MediaPath.Join(pathComponents)}");
+
             await entryIterator.DeleteEntry(entry.FullPathComponents);
         }
 
-        // delete root directory, if not a single file
-        if (!entryIterator.IsSingleFileEntryNext)
+        // delete root directory, if present and is not a single file
+        if (!entryIterator.IsSingleFileEntryNext &&
+            entryIterator.PathComponents.Length == entryIterator.DirPathComponents.Length)
         {
-            await entryIterator.DeleteEntry(entryIterator.PathComponents);
+            OnInformationMessage($"{entryIterator.DirPathComponents[^1]}");
+            
+            await entryIterator.DeleteEntry(entryIterator.DirPathComponents);
         }
 
         await entryIterator.Flush();
-        
+
+        stopwatch.Stop();
+
+        var stats = new List<string>();
+        if (dirsCount > 0 || filesCount == 0)
+        {
+            stats.Add($"{dirsCount} {(dirsCount > 1 ? "directories" : "directory")}");
+        }
+        if (filesCount > 0 || dirsCount == 0)
+        {
+            stats.Add($"{filesCount} {(filesCount == 1 ? "file" : "files")}");
+        }
+        stats.Add($"{totalBytes.FormatBytes()} deleted in {stopwatch.Elapsed.FormatElapsed()}");
+
+        OnInformationMessage(string.Join(", ", stats));
+
         return new Result();
     }
     
@@ -80,8 +134,16 @@ public class FsDelCommand(
                 return new Result<IEntryIterator>(mediaResult.Error);
             }
 
-            return await GetDirectoryEntryIterator(path, true, uaeMetadata,
+            var directoryEntryIteratorResult = await GetDirectoryEntryIterator(path, true, uaeMetadata,
                 new MemoryAppCache());
+            if (directoryEntryIteratorResult.IsFaulted)
+            {
+                return new Result<IEntryIterator>(directoryEntryIteratorResult.Error);
+            }
+            var initializeResult = await directoryEntryIteratorResult.Value.Initialize();
+            return initializeResult.IsFaulted
+                ? new Result<IEntryIterator>(initializeResult.Error)
+                : directoryEntryIteratorResult;
         }
 
         var dataType = await commandHelper.DetectDataType(mediaResult.Value.MediaPath);
@@ -91,6 +153,10 @@ public class FsDelCommand(
         {
             var entryIteratorResult = await GetDirectoryEntryIterator(path, true, uaeMetadata,
                 new MemoryAppCache());
+            if (entryIteratorResult.IsFaulted)
+            {
+                return new Result<IEntryIterator>(entryIteratorResult.Error);
+            }
             var initializeResult = await entryIteratorResult.Value.Initialize();
             return initializeResult.IsFaulted
                 ? new Result<IEntryIterator>(initializeResult.Error)

--- a/src/Hst.Imager.Core/Commands/IEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/IEntryIterator.cs
@@ -1,5 +1,6 @@
 ﻿using Hst.Core;
 using Hst.Imager.Core.Models;
+using Hst.Imager.Core.PathComponents;
 
 namespace Hst.Imager.Core.Commands;
 
@@ -11,6 +12,7 @@ using Entry = Models.FileSystems.Entry;
 
 public interface IEntryIterator : IDisposable
 {
+    IMediaPath MediaPath { get; }
     Task<Result> Initialize();
     string[] PathComponents { get; }
     string[] DirPathComponents { get; }

--- a/src/Hst.Imager.Core/Commands/Iso9660EntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/Iso9660EntryIterator.cs
@@ -36,7 +36,7 @@ public class Iso9660EntryIterator : IEntryIterator
     public Iso9660EntryIterator(Stream stream, string rootPath, CDReader cdReader, bool recursive)
     {
         this.stream = stream;
-        mediaPath = MediaPath.GenericMediaPath;
+        mediaPath = Core.PathComponents.MediaPath.GenericMediaPath;
         this.rootPath = string.IsNullOrEmpty(rootPath) ? string.Empty : rootPath;
         this.cdReader = cdReader;
         this.recursive = recursive;
@@ -51,6 +51,8 @@ public class Iso9660EntryIterator : IEntryIterator
         cdReader.Dispose();
         stream.Dispose();
     }
+
+    public IMediaPath MediaPath => mediaPath;
 
     public Task<Result> Initialize()
     {

--- a/src/Hst.Imager.Core/Commands/LhaArchiveEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/LhaArchiveEntryIterator.cs
@@ -37,7 +37,7 @@ public class LhaArchiveEntryIterator : IEntryIterator
     public LhaArchiveEntryIterator(Stream stream, string rootPath, LhaArchive lhaArchive, bool recursive)
     {
         this.stream = stream;
-        mediaPath = MediaPath.LhaArchivePath;
+        mediaPath = Core.PathComponents.MediaPath.LhaArchivePath;
         this.rootPath = rootPath;
         this.lhaArchive = lhaArchive;
         this.recursive = recursive;
@@ -53,6 +53,8 @@ public class LhaArchiveEntryIterator : IEntryIterator
         lhaArchive.Dispose();
         stream.Dispose();
     }
+
+    public IMediaPath MediaPath => mediaPath;
 
     public async Task<Result> Initialize()
     {

--- a/src/Hst.Imager.Core/Commands/LzwArchiveEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/LzwArchiveEntryIterator.cs
@@ -2,6 +2,7 @@
 using Hst.Core;
 using Hst.Imager.Core.Helpers;
 using Hst.Imager.Core.Models;
+using Hst.Imager.Core.PathComponents;
 
 namespace Hst.Imager.Core.Commands;
 
@@ -35,6 +36,8 @@ public class LzwArchiveEntryIterator : IEntryIterator
     public void Dispose()
     {
     }
+
+    public IMediaPath MediaPath => Core.PathComponents.MediaPath.GenericMediaPath;
 
     public Task<Result> Initialize()
     {

--- a/src/Hst.Imager.Core/Commands/LzxArchiveEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/LzxArchiveEntryIterator.cs
@@ -38,7 +38,7 @@ public class LzxArchiveEntryIterator : IEntryIterator
     public LzxArchiveEntryIterator(Stream stream, string rootPath, LzxArchive lzxArchive, bool recursive)
     {
         this.stream = stream;
-        mediaPath = MediaPath.LzxArchivePath;
+        mediaPath = Core.PathComponents.MediaPath.LzxArchivePath;
         this.rootPath = rootPath;
         this.lzxArchive = lzxArchive;
         this.recursive = recursive;
@@ -65,6 +65,8 @@ public class LzxArchiveEntryIterator : IEntryIterator
     }
 
     public void Dispose() => Dispose(true);
+
+    public IMediaPath MediaPath => mediaPath;
 
     public async Task<Result> Initialize()
     {

--- a/src/Hst.Imager.Core/Commands/UdfEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/UdfEntryIterator.cs
@@ -63,6 +63,8 @@ public class UdfEntryIterator : IEntryIterator
 
     public void Dispose() => Dispose(true);
 
+    public IMediaPath MediaPath => mediaPath;
+
     public Task<Result> Initialize()
     {
         return Task.FromResult(new Result());

--- a/src/Hst.Imager.Core/Commands/ZipArchiveEntryIterator.cs
+++ b/src/Hst.Imager.Core/Commands/ZipArchiveEntryIterator.cs
@@ -39,7 +39,7 @@ public class ZipArchiveEntryIterator : IEntryIterator
     public ZipArchiveEntryIterator(Stream stream, string rootPath, ZipArchive zipArchive, bool recursive)
     {
         this.stream = stream;
-        mediaPath = MediaPath.ZipArchivePath;
+        mediaPath = Core.PathComponents.MediaPath.ZipArchivePath;
         this.rootPath = rootPath;
         this.zipArchive = zipArchive;
         this.recursive = recursive;
@@ -65,7 +65,9 @@ public class ZipArchiveEntryIterator : IEntryIterator
 
         throw new InvalidOperationException("File system entry iterator not initialized");
     }
-    
+
+    public IMediaPath MediaPath => mediaPath;
+
     public Task<Result> Initialize()
     {
         zipEntries = zipArchive.Entries.OrderBy(x => x.FullName).ToList();


### PR DESCRIPTION
This PR adds fs del command to hst imager console. Fixes fs del command deleting deepest paths first. Fixes fs del command writing delete entry progress messages