### PR TITLE
Fix rdb part add start cylinder option

### DIFF
--- a/src/Hst.Imager.ConsoleApp/CommandHandler.cs
+++ b/src/Hst.Imager.ConsoleApp/CommandHandler.cs
@@ -575,7 +575,7 @@ namespace Hst.Imager.ConsoleApp
 
         public static async Task RdbPartAdd(string path, string name, string dosType, string size, uint? reserved,
             uint? preAlloc, uint? buffers, string maxTransfer, string mask, bool noMount, bool bootable, int? priority,
-            int? fileSystemBlockSize, bool useExperimental, uint startCylinder)
+            int? fileSystemBlockSize, bool useExperimental, uint? startCylinder)
         {
             using var commandHelper = GetCommandHelper();
             await Execute(new RdbPartAddCommand(GetLogger<RdbPartAddCommand>(), commandHelper,

--- a/src/Hst.Imager.ConsoleApp/RdbCommandFactory.cs
+++ b/src/Hst.Imager.ConsoleApp/RdbCommandFactory.cs
@@ -335,7 +335,7 @@
                 ["--use-experimental"],
                 description: "Use experimental partition sizes.");
 
-            var startCylinderOption = new Option<uint>(
+            var startCylinderOption = new Option<uint?>(
                 name: "StartCylinder",
                 description: "Start cylinder to add partition.");
 


### PR DESCRIPTION
This PR fixes rdb part add start cylinder option, which has value 0 by default instead of not defined